### PR TITLE
Fix spelling in --no-search-upward

### DIFF
--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -1,2 +1,2 @@
 #! /bin/env sh
-./gradlew --daemon --no-search-upwards
+./gradlew --daemon --no-search-upward


### PR DESCRIPTION
Fixed spelling on the pre-commit script. It is just --no-search-upward without a s at the end
