### PR TITLE
Add getPlayer by Username (still unimplemented)

### DIFF
--- a/src/main/java/org/spongepowered/mod/SpongeGame.java
+++ b/src/main/java/org/spongepowered/mod/SpongeGame.java
@@ -125,4 +125,9 @@ public final class SpongeGame implements Game {
     public Player getPlayer(UUID uniqueId) {
         throw new UnsupportedOperationException();
     }
+    
+    @Override
+    public Player getPlayer(String username) {
+        throw new UnsupportedOperationException();
+    }
 }


### PR DESCRIPTION
Despite a player name being deprecated it is still required. Players won't type UUIDS when using commands

API PR: https://github.com/SpongePowered/SpongeAPI/pull/109
