### PR TITLE
Event Handling change

### DIFF
--- a/src/main/java/org/spongepowered/mod/asm/util/ASMEventListenerHolderFactory.java
+++ b/src/main/java/org/spongepowered/mod/asm/util/ASMEventListenerHolderFactory.java
@@ -1,0 +1,217 @@
+/**
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.mod.asm.util;
+
+import static org.objectweb.asm.Opcodes.ACC_PUBLIC;
+import static org.objectweb.asm.Opcodes.ACC_STATIC;
+import static org.objectweb.asm.Opcodes.ACC_SUPER;
+import static org.objectweb.asm.Opcodes.ALOAD;
+import static org.objectweb.asm.Opcodes.INVOKESPECIAL;
+import static org.objectweb.asm.Opcodes.RETURN;
+import static org.objectweb.asm.Opcodes.V1_6;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.objectweb.asm.AnnotationVisitor;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Type;
+import org.objectweb.asm.util.CheckClassAdapter;
+import org.spongepowered.mod.SpongeMod;
+import org.spongepowered.mod.event.EventListenerHolder;
+
+import cpw.mods.fml.common.eventhandler.Event;
+import cpw.mods.fml.common.eventhandler.EventPriority;
+
+public class ASMEventListenerHolderFactory {
+
+    private static volatile ClassLoaderAccess loaderAccess = null;
+    private static final Map<HashTriple, Class<?>> cache = new ConcurrentHashMap<HashTriple, Class<?>>();
+    private static final Object classCreationLock = new Object();
+
+    private static int classId = 0;
+
+    @SuppressWarnings("unchecked")
+    public static EventListenerHolder<Event> getNewEventListenerHolder(Class<?> eventClass, EventPriority priority, boolean canceled) {
+        HashTriple t = new HashTriple(eventClass, priority, canceled);
+
+        Class<?> clazz = cache.get(t);
+        if (clazz == null) {
+            synchronized (classCreationLock) {
+                clazz = cache.get(t);
+                if (clazz == null) {
+                    clazz = getClass(eventClass, priority, canceled);
+                    if (clazz != null) {
+                        cache.put(t, clazz);
+                    }
+                }
+            }
+        }
+        try {
+            return (EventListenerHolder<Event>) clazz.newInstance();
+        } catch (InstantiationException e) {
+            ;
+        } catch (IllegalAccessException e) {
+            ;
+        }
+        return null;
+    }
+
+    public static Class<?> getClass(Class<?> eventClass, EventPriority priority, boolean canceled) {
+        ClassWriter cwRaw = new ClassWriter(0);
+        CheckClassAdapter cw = new CheckClassAdapter(cwRaw);
+
+        MethodVisitor mv;
+        AnnotationVisitor av0;
+
+        String className = getClassName(eventClass, priority, canceled);
+        String classNameInternal = className.replace('.', '/');
+
+        String invokeMethodDesc = "(" + Type.getDescriptor(eventClass) + ")V";
+
+        String eventPriorityName = priority.name();
+
+        cw.visit(V1_6, ACC_PUBLIC + ACC_SUPER, classNameInternal, null, "org/spongepowered/mod/event/EventListenerHolder", null);
+
+        cw.visitInnerClass("net/minecraftforge/event/world/BlockEvent$BreakEvent", "net/minecraftforge/event/world/BlockEvent", "BreakEvent", 
+                ACC_PUBLIC + ACC_STATIC);
+
+        {
+            mv = cw.visitMethod(ACC_PUBLIC, "<init>", "()V", null, null);
+            mv.visitCode();
+            mv.visitVarInsn(ALOAD, 0);
+            mv.visitMethodInsn(INVOKESPECIAL, "org/spongepowered/mod/event/EventListenerHolder", "<init>", "()V", false);
+            mv.visitInsn(RETURN);
+            mv.visitMaxs(1, 1);
+            mv.visitEnd();
+        }
+        {
+            mv = cw.visitMethod(ACC_PUBLIC, "invoke", invokeMethodDesc, null, null);
+            {
+                av0 = mv.visitAnnotation("Lcpw/mods/fml/common/eventhandler/SubscribeEvent;", true);
+                av0.visitEnum("priority", "Lcpw/mods/fml/common/eventhandler/EventPriority;", eventPriorityName);
+                av0.visit("receiveCanceled", (Boolean) canceled);
+                av0.visitEnd();
+            }
+            mv.visitCode();
+            mv.visitVarInsn(ALOAD, 0);
+            mv.visitVarInsn(ALOAD, 1);
+            mv.visitMethodInsn(INVOKESPECIAL, "org/spongepowered/mod/event/EventListenerHolder", "invoke", "(Ljava/lang/Object;)V", false);
+            mv.visitInsn(RETURN);
+            mv.visitMaxs(2, 2);
+            mv.visitEnd();
+        }
+        cw.visitEnd();
+
+        if (loaderAccess == null) {
+            loaderAccess = new ClassLoaderAccess();
+        }
+        return loaderAccess.defineClass(className, cwRaw.toByteArray());
+    }
+
+    private static class HashTriple {
+
+        private final Class<?> eventClass;
+        private final EventPriority priority;
+        private final Boolean canceled;
+        private final int hashCode;
+
+        public HashTriple(Class<?> eventClass, EventPriority priority, boolean canceled) {
+            this.eventClass = eventClass;
+            this.priority = priority;
+            this.canceled = canceled;
+            this.hashCode = eventClass.hashCode() + priority.hashCode() + this.canceled.hashCode();
+        }
+
+        @Override
+        public int hashCode() {
+            return hashCode;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (!(o instanceof HashTriple)) {
+                return false;
+            } else {
+                HashTriple t = (HashTriple) o;
+                if (t.hashCode != hashCode) {
+                    return false;
+                }
+                return t.eventClass.equals(eventClass) && t.priority.equals(priority) && t.canceled.equals(canceled);
+            }
+        }
+    }
+
+    private static String getClassName(Class<?> eventClass, EventPriority priority, boolean canceled) {
+        int id = classId++;
+        String prefix = ASMEventListenerHolderFactory.class.getName();
+        String eventClassName = eventClass.getSimpleName();
+        String priorityString = priority.name();
+        String canceledString = canceled ? "Cancel" : "NoCancel";
+        return prefix + "_" + id + "_" + eventClassName + "_" + priorityString + "_" + canceledString;
+    }
+
+    private static class ClassLoaderAccess {
+        private final Method defineClassMethod;
+        private final ClassLoader loader;
+
+        public ClassLoaderAccess() {
+            loader = SpongeMod.instance.getClass().getClassLoader();
+            Method m = null;
+            try {
+                Class<?> clazz = loader.getClass();
+                while (clazz != null) {
+                    try {
+                        m = clazz.getDeclaredMethod("defineClass", String.class, byte[].class, int.class, int.class);
+                        m.setAccessible(true);
+                        break;
+                    } catch (NoSuchMethodException e) {
+                        clazz = clazz.getSuperclass();
+                        continue;
+                    }
+                }
+            } catch (SecurityException e) {
+                e.printStackTrace();
+            }
+            defineClassMethod = m;
+        }
+
+        public Class<?> defineClass(String className, byte[] b) {
+            try {
+                return (Class<?>) defineClassMethod.invoke(this.loader, className, b, 0, b.length);
+            } catch (IllegalAccessException e) {
+                ;
+            } catch (IllegalArgumentException e) {
+                ;
+            } catch (InvocationTargetException e) {
+                ;
+            }
+            return null;
+        }
+    }
+}

--- a/src/main/java/org/spongepowered/mod/event/EventListener.java
+++ b/src/main/java/org/spongepowered/mod/event/EventListener.java
@@ -22,10 +22,10 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.mod.asm;
+package org.spongepowered.mod.event;
 
 public interface EventListener<T> {
 
     public void invoke(T event);
-    
+
 }

--- a/src/main/java/org/spongepowered/mod/event/EventListenerHolder.java
+++ b/src/main/java/org/spongepowered/mod/event/EventListenerHolder.java
@@ -1,0 +1,90 @@
+/**
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.mod.event;
+
+public abstract class EventListenerHolder<T> {
+
+    protected PriorityEventListener<T>[] listeners;
+
+    @SuppressWarnings({"unchecked", "rawtypes" })
+    protected EventListenerHolder() {
+        this.listeners = new PriorityEventListener[0];
+    }
+
+    public boolean isEmpty() {
+        return listeners.length == 0;
+    }
+
+    public void add(PriorityEventListener<T> listener) {
+        if (listener.getHolder() != null) {
+            throw new IllegalArgumentException("Listener already contained in a listener holder");
+        }
+        listener.setHolder(this);
+
+        @SuppressWarnings({"unchecked", "rawtypes" })
+        PriorityEventListener<T>[] newListeners = new PriorityEventListener[listeners.length + 1];
+        int i;
+        for (i = 0; i < listeners.length; i++) {
+            if (listener.compareTo(listeners[i]) <= 0) {
+                break;
+            }
+            newListeners[i] = listeners[i];
+        }
+        newListeners[i++] = listener;
+        for (; i < newListeners.length; i++) {
+            newListeners[i] = listeners[i - 1];
+        }
+        listeners = newListeners;
+    }
+
+    public void remove(PriorityEventListener<T> listener) {
+        if (listener.getHolder() != this) {
+            throw new IllegalArgumentException("EventListenerHolder does not contain event");
+        }
+        @SuppressWarnings({"unchecked", "rawtypes" })
+        PriorityEventListener<T>[] newListeners = new PriorityEventListener[listeners.length - 1];
+        int i = 0;
+        int j = 0;
+        while (i < listeners.length) {
+            if (listeners[i] == listener) {
+                i++;
+                break;
+            }
+            newListeners[j++] = listeners[i++];
+        }
+        while (i < listeners.length) {
+            newListeners[j++] = listeners[i++];
+        }
+        listener.setHolder(null);
+        listeners = newListeners;
+    }
+
+    public void invoke(T event) {
+        for (int i = 0; i < listeners.length; i++) {
+            listeners[i].invoke(event);
+        }
+    }
+
+}

--- a/src/main/java/org/spongepowered/mod/event/PriorityEventListener.java
+++ b/src/main/java/org/spongepowered/mod/event/PriorityEventListener.java
@@ -25,16 +25,24 @@
 package org.spongepowered.mod.event;
 
 import org.spongepowered.api.event.Order;
-import org.spongepowered.mod.asm.EventListener;
 
 public class PriorityEventListener<T> implements EventListener<T>, Comparable<PriorityEventListener<T>> {
-    
+
     private final EventListener<T> listener;
     private final Order order;
+    private EventListenerHolder<T> holder;
     
     public PriorityEventListener(Order order, EventListener<T> listener) {
         this.listener = listener;
         this.order = order;
+    }
+
+    public EventListenerHolder<T> getHolder() {
+        return holder;
+    }
+
+    public void setHolder(EventListenerHolder<T> holder) {
+        this.holder = holder;
     }
 
     @Override

--- a/src/main/java/org/spongepowered/mod/event/PriorityMap.java
+++ b/src/main/java/org/spongepowered/mod/event/PriorityMap.java
@@ -24,23 +24,26 @@
  */
 package org.spongepowered.mod.event;
 
-import static cpw.mods.fml.common.eventhandler.EventPriority.*;
+import static cpw.mods.fml.common.eventhandler.EventPriority.HIGH;
+import static cpw.mods.fml.common.eventhandler.EventPriority.HIGHEST;
+import static cpw.mods.fml.common.eventhandler.EventPriority.LOW;
+import static cpw.mods.fml.common.eventhandler.EventPriority.LOWEST;
+import static cpw.mods.fml.common.eventhandler.EventPriority.NORMAL;
 
 import org.spongepowered.api.event.Order;
 
 import cpw.mods.fml.common.eventhandler.EventPriority;
 
 public class PriorityMap {
-    
-    private final static EventPriority[] eventPriorities;
-    private final static Order[] orders;
-    
+
+    private static final EventPriority[] eventPriorities;
+    private static final Order[] orders;
+
     static {
-        // TODO - needs higher resolution
         eventPriorities = new EventPriority[] {HIGHEST, HIGHEST, HIGH, HIGH, NORMAL, LOW, LOW, LOWEST, LOWEST};
         orders = Order.values();
     }
-    
+
     private PriorityMap() {
     }
     
@@ -51,5 +54,4 @@ public class PriorityMap {
     public static Order getOrder(EventPriority priority) {
         return orders[priority.ordinal()];
     }
-
 }

--- a/src/main/java/org/spongepowered/mod/event/SpongeEventBus.java
+++ b/src/main/java/org/spongepowered/mod/event/SpongeEventBus.java
@@ -1,0 +1,95 @@
+/**
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.mod.event;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+import net.minecraftforge.common.MinecraftForge;
+
+import org.spongepowered.api.event.SpongeEventHandler;
+import org.spongepowered.mod.asm.util.ASMEventListenerHolderFactory;
+
+import cpw.mods.fml.common.eventhandler.Event;
+import cpw.mods.fml.common.eventhandler.EventPriority;
+
+public class SpongeEventBus {
+    
+    private final Map<Class<?>, Map<EventPriority, EventListenerHolder<Event>>> eventAndPriorityToEventListenerHolderMap;
+    
+    public SpongeEventBus() {
+        this.eventAndPriorityToEventListenerHolderMap = new HashMap<Class<?>, Map<EventPriority, EventListenerHolder<Event>>>();
+    }
+    
+    public void add(Class<?> implementingEvent, SpongeEventHandler annotation, PriorityEventListener<Event> listener) {
+        EventListenerHolder<Event> holder = getEventHolder(implementingEvent, annotation);
+        holder.add(listener);
+    }
+    
+    public void remove(PriorityEventListener<Event> listener) {
+        Iterator<Map<EventPriority, EventListenerHolder<Event>>> mapIterator = eventAndPriorityToEventListenerHolderMap.values().iterator();
+        while (mapIterator.hasNext()) {
+            Map<EventPriority, EventListenerHolder<Event>> map = mapIterator.next();
+            Iterator<EventListenerHolder<Event>> holderIterator = map.values().iterator();
+            while (holderIterator.hasNext()) {
+                EventListenerHolder<Event> holder = holderIterator.next();
+                if (holder != listener.getHolder()) {
+                    continue;
+                }
+                holder.remove(listener);
+                if (holder.isEmpty()) {
+                    MinecraftForge.EVENT_BUS.unregister(holder);
+                    holderIterator.remove();
+                }
+            }
+            if (map.isEmpty()) {
+                mapIterator.remove();
+            }
+        }
+    }
+    
+    private EventListenerHolder<Event> getEventHolder(Class<?> implementingEvent, SpongeEventHandler annotation) {
+        
+        Map<EventPriority, EventListenerHolder<Event>> priorityHolderMap = eventAndPriorityToEventListenerHolderMap.get(implementingEvent);
+        
+        if (priorityHolderMap == null) {
+            priorityHolderMap = new HashMap<EventPriority, EventListenerHolder<Event>>();
+            eventAndPriorityToEventListenerHolderMap.put(implementingEvent, priorityHolderMap);
+        }
+
+        EventPriority priority = PriorityMap.getEventPriority(annotation.order());
+        EventListenerHolder<Event> eventListenerHolder = priorityHolderMap.get(priority);
+        
+        if (eventListenerHolder == null) {
+            eventListenerHolder = ASMEventListenerHolderFactory.getNewEventListenerHolder(implementingEvent, priority, !annotation.ignoreCancelled());
+            priorityHolderMap.put(priority, eventListenerHolder);
+            MinecraftForge.EVENT_BUS.register(eventListenerHolder);
+        }
+        
+        return eventListenerHolder;
+    }
+
+}


### PR DESCRIPTION
This removes direct accessing of the Forge ListenerLists in their EventBus.   An EventListenerHolder is registered with Forge for each event-type & priority pair.   If the last listener in the holder is unregistered, then the holder is unregistered with Forge.

EventListenerHolders are generated dynamically using ASM so they have the SubscribeEvent annotation with the correct priority and cancel status. 

The EventListenerHolders calls all the sponge listeners.  Priorities are grouped since Sponge has more priorities than Forge.

```
PRE & AFTER_PRE run at HIGHEST priority
FIRST & EARLY run at HIGH priority
DEFAULT runs at NORMAL priority
LATE & LAST run at LOW priority
BEFORE_POST & POST run at LOWEST priority
```
