### PR TITLE
Impl of Block/Item expansion

### DIFF
--- a/src/main/java/org/spongepowered/mod/mixin/block/MixinBlockState.java
+++ b/src/main/java/org/spongepowered/mod/mixin/block/MixinBlockState.java
@@ -26,6 +26,7 @@ package org.spongepowered.mod.mixin.block;
 
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
 
 import net.minecraft.block.properties.IProperty;
 import net.minecraft.block.state.BlockState;
@@ -36,6 +37,11 @@ import org.spongepowered.api.block.BlockProperty;
 import org.spongepowered.api.block.BlockType;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 
 @NonnullByDefault
 @Mixin(BlockState.StateImplementation.class)
@@ -46,13 +52,26 @@ public abstract class MixinBlockState extends BlockStateBase implements org.spon
         return (BlockType) getBlock();
     }
 
-    // TODO: This method requires mixin support for methods with the same name and signature.
-    //@Override
-    //public abstract ImmutableMap<BlockProperty<?>, ? extends Comparable<?>> getProperties();
+    @Shadow
+    @SuppressWarnings("rawtypes")
+    private final ImmutableMap properties = null;
 
-    // TODO: This method requires mixin support for methods with the same name and signature.
-    //@Override
-    //public abstract Collection<String> getPropertyNames();
+    @Override
+    @SuppressWarnings("unchecked")
+    public ImmutableMap<BlockProperty<?>, ? extends Comparable<?>> getProperties() {
+        return this.properties;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public Collection<String> getPropertyNames() {
+        ImmutableMap<IProperty, Comparable<?>> properties = ((IBlockState) this).getProperties();
+        List<String> names = Lists.newArrayListWithCapacity(properties.size());
+        for (IProperty property : properties.keySet()) {
+            names.add(property.getName());
+        }
+        return Collections.unmodifiableCollection(names);
+    }
 
     @Override
     @SuppressWarnings("unchecked")

--- a/src/main/java/org/spongepowered/mod/mixin/block/MixinBlockType.java
+++ b/src/main/java/org/spongepowered/mod/mixin/block/MixinBlockType.java
@@ -25,6 +25,8 @@
 package org.spongepowered.mod.mixin.block;
 
 import net.minecraft.block.Block;
+import net.minecraft.block.BlockFalling;
+import net.minecraft.block.BlockLiquid;
 import net.minecraft.block.state.IBlockState;
 
 import org.spongepowered.api.block.BlockState;
@@ -49,6 +51,15 @@ public abstract class MixinBlockType implements BlockType {
     public abstract String shadow$getUnlocalizedName();
 
     @Shadow
+    public abstract boolean isSolidFullCube();
+
+    @Shadow
+    public abstract boolean getEnableStats();
+
+    @Shadow
+    public abstract int getLightValue();
+
+    @Shadow
     public abstract IBlockState getStateFromMeta(int meta);
 
     @Override
@@ -71,4 +82,30 @@ public abstract class MixinBlockType implements BlockType {
     public BlockState getStateFromDataValue(byte data) {
         return (BlockState) getStateFromMeta(data);
     }
+
+    @Override
+    public boolean isLiquid() {
+        return BlockLiquid.class.isAssignableFrom(this.getClass());
+    }
+
+    @Override
+    public boolean isSolidCube() {
+        return isSolidFullCube();
+    }
+
+    @Override
+    public boolean isAffectedByGravity() {
+        return BlockFalling.class.isAssignableFrom(this.getClass());
+    }
+
+    @Override
+    public boolean areStatisticsEnabled() {
+        return getEnableStats();
+    }
+
+    @Override
+    public float getEmittedLight() {
+        return 15F / getLightValue();
+    }
+
 }

--- a/src/main/java/org/spongepowered/mod/mixin/item/MixinItemType.java
+++ b/src/main/java/org/spongepowered/mod/mixin/item/MixinItemType.java
@@ -44,6 +44,9 @@ public abstract class MixinItemType implements ItemType {
     @Shadow(prefix = "shadow$")
     public abstract String shadow$getUnlocalizedName();
 
+    @Shadow
+    private int maxDamage;
+
     @Override
     public String getId() {
         return Item.itemRegistry.getNameForObject(this).toString();
@@ -60,5 +63,10 @@ public abstract class MixinItemType implements ItemType {
     @Override
     public int getMaxStackQuantity() {
         return getItemStackLimit();
+    }
+
+    @Override
+    public int getMaxDamage() {
+        return this.maxDamage;
     }
 }

--- a/src/main/java/org/spongepowered/mod/wrapper/BlockWrapper.java
+++ b/src/main/java/org/spongepowered/mod/wrapper/BlockWrapper.java
@@ -236,13 +236,11 @@ public class BlockWrapper implements BlockLoc {
 
     @Override
     public boolean isPassable() {
-        // TODO
-        return false;
+        return this.handle.getBlockState(this.pos).getBlock().isPassable(this.handle, this.pos);
     }
 
     @Override
     public boolean isFaceFlammable(Direction direction) {
-        // TODO
-        return false;
+        return this.handle.getBlockState(this.pos).getBlock().isFlammable(this.handle, this.pos, getNotchDirection(direction));
     }
 }


### PR DESCRIPTION
This PR implements the changes to the `BlockType` and `ItemType` interfaces in spongepowered/spongeapi#309. Additionally it implements the previously unimplemented methods `getProperties()` and `getPropertyNames()` in `MixinBlockState`.

The travis build will understandably fail until the associated PR to SpongeAPI is pulled.
