### PR TITLE
Add constraints to @Overwrite methods in mixins

### DIFF
--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/vehicle/MixinEntityMinecart.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/vehicle/MixinEntityMinecart.java
@@ -55,7 +55,7 @@ public abstract class MixinEntityMinecart extends Entity implements Minecart, IM
     public abstract double getMaxSpeed();
 
     // this method overwrites the vanilla accessor for maximum speed
-    @Overwrite
+    @Overwrite(constraints = "FORGE(1371+)")
     public double getMaximumSpeed() {
         return this.maxSpeed;
     }

--- a/src/main/java/org/spongepowered/mod/mixin/core/event/MixinEventBus.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/event/MixinEventBus.java
@@ -48,7 +48,7 @@ public abstract class MixinEventBus {
     @Shadow
     private IEventExceptionHandler exceptionHandler;
 
-    @Overwrite
+    @Overwrite(constraints = "FML(1371)")
     public boolean post(Event event) {
         IEventListener[] listeners = event.getListenerList().getListeners(this.busID);
 

--- a/src/main/java/org/spongepowered/mod/mixin/core/event/MixinEventBus.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/event/MixinEventBus.java
@@ -48,7 +48,7 @@ public abstract class MixinEventBus {
     @Shadow
     private IEventExceptionHandler exceptionHandler;
 
-    @Overwrite(constraints = "FML(1371)")
+    @Overwrite(constraints = "FML(1371 +10)")
     public boolean post(Event event) {
         IEventListener[] listeners = event.getListenerList().getListeners(this.busID);
 

--- a/src/main/java/org/spongepowered/mod/mixin/core/forge/MixinDimensionManager.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/forge/MixinDimensionManager.java
@@ -52,7 +52,7 @@ public abstract class MixinDimensionManager {
     @Shadow
     private static ArrayList<Integer> unloadQueue;
 
-    @Overwrite
+    @Overwrite(constraints = "FORGE(1371+)")
     public static boolean registerProviderType(int id, Class<? extends WorldProvider> provider, boolean keepLoaded) {
         if (providers.containsKey(id)) {
             return false;
@@ -86,7 +86,7 @@ public abstract class MixinDimensionManager {
         return true;
     }
 
-    @Overwrite
+    @Overwrite(constraints = "FORGE(1371+)")
     public static void unloadWorld(int id) {
         WorldServer world = DimensionManager.getWorld(id);
         if (world != null && !((WorldProperties) world.getWorldInfo()).doesKeepSpawnLoaded()) {

--- a/src/main/java/org/spongepowered/mod/mixin/core/server/MixinMinecraftServer.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/server/MixinMinecraftServer.java
@@ -97,7 +97,7 @@ public abstract class MixinMinecraftServer implements Server, ConsoleSource, Sub
     @Shadow protected abstract void outputPercentRemaining(String message, int percent);
     @Shadow protected abstract void clearCurrentTask();
 
-    @Overwrite
+    @Overwrite(constraints = "FORGE(1371 +10)")
     protected void loadAllWorlds(String overworldFolder, String unused, long seed, WorldType type, String generator) {
         this.convertMapIfNeeded(overworldFolder);
         this.setUserMessage("menu.loadingLevel");
@@ -185,7 +185,7 @@ public abstract class MixinMinecraftServer implements Server, ConsoleSource, Sub
         this.initialWorldChunkLoad();
     }
 
-    @Overwrite
+    @Overwrite(constraints = "FORGE(1371 +50)")
     protected void initialWorldChunkLoad() {
         for (WorldServer worldserver : DimensionManager.getWorlds()) {
             WorldProperties worldProperties = ((World) worldserver).getProperties();

--- a/src/main/java/org/spongepowered/mod/mixin/core/server/MixinServerConfigurationManager.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/server/MixinServerConfigurationManager.java
@@ -89,6 +89,8 @@ import java.util.List;
 @Mixin(ServerConfigurationManager.class)
 public abstract class MixinServerConfigurationManager implements IMixinServerConfigurationManager {
 
+    private static final String $OVERWRITE_POLICY = "FORGE(1371 +10)";
+
     @Shadow
     private static Logger logger;
 
@@ -124,7 +126,7 @@ public abstract class MixinServerConfigurationManager implements IMixinServerCon
     public abstract void playerLoggedIn(EntityPlayerMP playerIn);
 
     @SuppressWarnings("rawtypes")
-    @Overwrite(aliases = "initializeConnectionToPlayer")
+    @Overwrite(aliases = "initializeConnectionToPlayer", constraints = MixinServerConfigurationManager.$OVERWRITE_POLICY)
     public void initializeConnectionToPlayer(NetworkManager netManager, EntityPlayerMP playerIn, NetHandlerPlayServer nethandlerplayserver) {
         GameProfile gameprofile = playerIn.getGameProfile();
         PlayerProfileCache playerprofilecache = this.mcServer.getPlayerProfileCache();
@@ -229,7 +231,7 @@ public abstract class MixinServerConfigurationManager implements IMixinServerCon
     }
 
     @SuppressWarnings({"unused", "unchecked"})
-    @Overwrite
+    @Overwrite(constraints = MixinServerConfigurationManager.$OVERWRITE_POLICY)
     public EntityPlayerMP recreatePlayerEntity(EntityPlayerMP playerIn, int targetDimension, boolean conqueredEnd) {
         // Phase 1 - check if the player is allowed to respawn in same dimension
         net.minecraft.world.World world = this.mcServer.worldServerForDimension(targetDimension);
@@ -359,7 +361,7 @@ public abstract class MixinServerConfigurationManager implements IMixinServerCon
         return playerIn;
     }
 
-    @Overwrite
+    @Overwrite(constraints = MixinServerConfigurationManager.$OVERWRITE_POLICY)
     public void setPlayerManager(WorldServer[] worldServers) {
         if (this.playerNBTManagerObj != null) {
             return;
@@ -368,7 +370,7 @@ public abstract class MixinServerConfigurationManager implements IMixinServerCon
         worldServers[0].getWorldBorder().addListener(new PlayerBorderListener());
     }
 
-    @Overwrite
+    @Overwrite(constraints = MixinServerConfigurationManager.$OVERWRITE_POLICY)
     public void updateTimeAndWeatherForPlayer(EntityPlayerMP playerIn, WorldServer worldIn) {
         net.minecraft.world.border.WorldBorder worldborder = worldIn.getWorldBorder();
         playerIn.playerNetServerHandler.sendPacket(new S44PacketWorldBorder(worldborder, S44PacketWorldBorder.Action.INITIALIZE));

--- a/src/main/java/org/spongepowered/mod/mixin/core/world/MixinSaveHandler.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/world/MixinSaveHandler.java
@@ -48,13 +48,15 @@ import java.io.IOException;
 @Mixin(net.minecraft.world.storage.SaveHandler.class)
 public abstract class MixinSaveHandler {
 
+    private static final String $OVERWRITE_POLICY = "FORGE(1371 +50)";
+
     @Shadow
     private File worldDirectory;
 
     @Shadow
     private long initializationTime;
 
-    @Overwrite
+    @Overwrite(constraints = MixinSaveHandler.$OVERWRITE_POLICY)
     public void checkSessionLock() throws MinecraftException {
         try {
             File file1 = new File(this.worldDirectory, "session.lock");
@@ -74,7 +76,7 @@ public abstract class MixinSaveHandler {
         }
     }
 
-    @Overwrite
+    @Overwrite(constraints = MixinSaveHandler.$OVERWRITE_POLICY)
     public WorldInfo loadWorldInfo() {
         File file1 = new File(this.worldDirectory, "level.dat");
         File file2 = new File(this.worldDirectory, "level.dat_old");
@@ -123,7 +125,7 @@ public abstract class MixinSaveHandler {
         return null;
     }
 
-    @Overwrite
+    @Overwrite(constraints = MixinSaveHandler.$OVERWRITE_POLICY)
     public void saveWorldInfoWithPlayer(WorldInfo worldInformation, NBTTagCompound tagCompound) {
         NBTTagCompound nbttagcompound1 = worldInformation.cloneNBTCompound(tagCompound);
         NBTTagCompound nbttagcompound2 = new NBTTagCompound();
@@ -188,7 +190,7 @@ public abstract class MixinSaveHandler {
         }
     }
 
-    @Overwrite
+    @Overwrite(constraints = MixinSaveHandler.$OVERWRITE_POLICY)
     public void saveWorldInfo(WorldInfo worldInformation) {
         NBTTagCompound nbttagcompound = worldInformation.getNBTTagCompound();
         NBTTagCompound nbttagcompound1 = new NBTTagCompound();

--- a/src/main/java/org/spongepowered/mod/mixin/core/world/MixinWorldProvider.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/world/MixinWorldProvider.java
@@ -59,7 +59,7 @@ public abstract class MixinWorldProvider implements Dimension, IMixinWorldProvid
     @Shadow public abstract String getDimensionName();
     @Shadow public abstract boolean canRespawnHere();
 
-    @Overwrite
+    @Overwrite(constraints = "FORGE(1371+)")
     public static WorldProvider getProviderForDimension(int dimension) {
         WorldProvider provider = net.minecraftforge.common.DimensionManager.createProviderFor(dimension);
         if (((IMixinWorldProvider) provider).getDimensionConfig() == null) {

--- a/src/main/java/org/spongepowered/mod/mixin/entityactivation/MixinWorld.java
+++ b/src/main/java/org/spongepowered/mod/mixin/entityactivation/MixinWorld.java
@@ -62,7 +62,7 @@ public abstract class MixinWorld implements World, IMixinWorld {
         }
     }
 
-    @Overwrite
+    @Overwrite(constraints = "FORGE(1371 +10)")
     public void updateEntityWithOptionalForce(net.minecraft.entity.Entity entity, boolean forceUpdate) {
         int i = MathHelper.floor_double(entity.posX);
         int j = MathHelper.floor_double(entity.posZ);


### PR DESCRIPTION
I'm pull-requesting this rather than committing directly because I'd like to get some feedback on the constraint ranges I've added here.

In a nutshell, constraints allow hard failures to be raised at both build and run time which have particular purposes:

* Forces us to keep on top of `@Overwrite` methods when bumping forge versions. Having a hard declaration on the annotation means that a contract is baked directly into the code which says "this overwrite is valid for this version and, say, the next 10 versions".

* Causes a hard crash when a user tries to run the coremod in a version of Forge which is just too far away from the version we built against for comfort. Basically we want to avoid the scenario where something is patched/fixed/improved in Forge, and our boistrous coremod comes along and just blithely overwrites the new stuff.

Thus the overwrite constraints aren't hard-and-fast, they're going to depend - on a per-method basis - on the anticipated volatility of the method in question, both in terms of how severe our changes are, and how often we anticipate the target method itself will change. Given we may know about the future (if working against an older forge version like we are right now), then we can even impose a hard upper bound on overwrites when we know the build number of a future breaking change.

Constraints use a pretty straightforward syntax, for a quick intro consult the [Constraint javadoc](http://jenkins.liteloader.com/job/Mixin/javadoc/org/spongepowered/asm/util/ConstraintParser.Constraint.html) which gives a bunch of examples.

For the constraints defined here, I've gone with a pretty straightforward approach of `1371+` (meaning 1371 and any later version) where I feel it's safe to do so. `1371 +10` for particularly hairy bits of code, and longer constraints varying between 50 and 100 for less critical bits of code which should nevertheless be periodically reviewed.

I suggest we make it a policy to never author a **new** constraint with a version lower than the version we're building against, but can feel free to let constraints trail a little bit when bumping forge versions depending on anticipated code volatility.

Welcome feedback and suggested adjustments to these values. I should mention that I [already committed](https://github.com/SpongePowered/Sponge/commit/d0e57450bdaa510c5c476bfc52f9dc7744d682b1) changes which provide a nice user-facing message when a constraint violation is encountered, which tells the user exactly what happens and suggests remedial actions.