### PR TITLE
Implement most SleepingEvents.

### DIFF
--- a/src/main/java/org/spongepowered/mod/event/SpongeForgeEventFactory.java
+++ b/src/main/java/org/spongepowered/mod/event/SpongeForgeEventFactory.java
@@ -91,6 +91,7 @@ import org.spongepowered.api.block.BlockTypes;
 import org.spongepowered.api.data.Transaction;
 import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.event.Event;
+import org.spongepowered.api.event.action.SleepingEvent;
 import org.spongepowered.api.event.block.ChangeBlockEvent;
 import org.spongepowered.api.event.block.InteractBlockEvent;
 import org.spongepowered.api.event.block.NotifyNeighborBlockEvent;
@@ -187,7 +188,7 @@ public class SpongeForgeEventFactory {
             } else if (clazz == PlayerPickupXpEvent.class) {
 
             } else if (clazz == PlayerSleepInBedEvent.class) {
-
+                return createPlayerSleepInBedEvent(event);
             } else if (clazz == PlayerUseItemEvent.Start.class) {
                 return createPlayerUseItemStartEvent(event);
             } else if (clazz == PlayerUseItemEvent.Tick.class) {
@@ -499,6 +500,21 @@ public class SpongeForgeEventFactory {
                 new PlayerInteractEvent((EntityPlayer) player.get(), action, pos, face.isPresent() ? face.get() : null,
                         (net.minecraft.world.World) player.get().getWorld());
         return forgeEvent;
+    }
+
+    public static PlayerSleepInBedEvent createPlayerSleepInBedEvent(Event event) {
+        if (!(event instanceof SleepingEvent.Pre)) {
+            throw new IllegalArgumentException("Event " + event + " is not a valid SleepingEvent.Pre event.");
+        }
+        
+        SleepingEvent.Pre spongeEvent = (SleepingEvent.Pre) event;
+        Optional<Player> player = spongeEvent.getCause().first(Player.class);
+        if (!player.isPresent()) {
+            return null;
+        }
+        Location<World> location = spongeEvent.getBed().getLocation().get();
+        BlockPos pos = new BlockPos(location.getBlockX(), location.getBlockY(), location.getBlockZ());
+        return new PlayerSleepInBedEvent((EntityPlayer) player.get(), pos);
     }
 
     public static PlayerUseItemEvent.Start createPlayerUseItemStartEvent(Event event) {

--- a/src/main/java/org/spongepowered/mod/event/SpongeForgeEventFactory.java
+++ b/src/main/java/org/spongepowered/mod/event/SpongeForgeEventFactory.java
@@ -78,7 +78,6 @@ import net.minecraftforge.event.entity.player.PlayerOpenContainerEvent;
 import net.minecraftforge.event.entity.player.PlayerPickupXpEvent;
 import net.minecraftforge.event.entity.player.PlayerSleepInBedEvent;
 import net.minecraftforge.event.entity.player.PlayerUseItemEvent;
-import net.minecraftforge.event.entity.player.PlayerWakeUpEvent;
 import net.minecraftforge.event.world.BlockEvent;
 import net.minecraftforge.event.world.BlockEvent.NeighborNotifyEvent;
 import net.minecraftforge.event.world.ChunkDataEvent;
@@ -197,8 +196,6 @@ public class SpongeForgeEventFactory {
                 return createPlayerUseItemStopEvent(event);
             } else if (clazz == PlayerUseItemEvent.Finish.class) {
                 return createPlayerUseItemFinishEvent(event);
-            } else if (clazz == PlayerWakeUpEvent.class) {
-
             } else {
                 return (net.minecraftforge.fml.common.eventhandler.Event) event;
             }

--- a/src/main/java/org/spongepowered/mod/event/SpongeModEventManager.java
+++ b/src/main/java/org/spongepowered/mod/event/SpongeModEventManager.java
@@ -37,6 +37,7 @@ import net.minecraftforge.event.entity.player.AttackEntityEvent;
 import net.minecraftforge.event.entity.player.EntityInteractEvent;
 import net.minecraftforge.event.entity.player.EntityItemPickupEvent;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
+import net.minecraftforge.event.entity.player.PlayerSleepInBedEvent;
 import net.minecraftforge.event.entity.player.PlayerUseItemEvent;
 import net.minecraftforge.event.terraingen.BiomeEvent;
 import net.minecraftforge.event.terraingen.DecorateBiomeEvent;
@@ -57,6 +58,7 @@ import net.minecraftforge.fml.common.gameevent.PlayerEvent;
 import org.spongepowered.api.event.Cancellable;
 import org.spongepowered.api.event.Event;
 import org.spongepowered.api.event.Order;
+import org.spongepowered.api.event.action.SleepingEvent;
 import org.spongepowered.api.event.block.ChangeBlockEvent;
 import org.spongepowered.api.event.block.InteractBlockEvent;
 import org.spongepowered.api.event.block.NotifyNeighborBlockEvent;
@@ -124,6 +126,7 @@ public class SpongeModEventManager extends SpongeEventManager {
                     .put(UseItemStackEvent.Finish.class, PlayerUseItemEvent.Finish.class)
                     .put(ClientConnectionEvent.Join.class, PlayerEvent.PlayerLoggedInEvent.class)
                     .put(ClientConnectionEvent.Disconnect.class, PlayerEvent.PlayerLoggedOutEvent.class)
+                    .put(SleepingEvent.Pre.class, PlayerSleepInBedEvent.class)
                     .build();
 
     public static final ImmutableMap<Class<? extends Event>, Class<? extends net.minecraftforge.fml.common.eventhandler.Event>> eventBulkMappings =

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/player/MixinEntityPlayer.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/player/MixinEntityPlayer.java
@@ -24,7 +24,7 @@
  */
 package org.spongepowered.mod.mixin.core.entity.player;
 
-import org.spongepowered.common.Sponge;
+import org.spongepowered.api.Sponge;
 import org.spongepowered.common.mixin.core.entity.living.MixinEntityLivingBase;
 import org.spongepowered.common.util.VecHelper;
 
@@ -85,7 +85,7 @@ public abstract class MixinEntityPlayer extends MixinEntityLivingBase {
         }
         
         SleepingEvent.Post post = SpongeEventFactory.createSleepingEventPost(Sponge.getGame(), Cause.of(this), this.getWorld().createSnapshot(VecHelper.toVector(this.playerLocation)), Optional.ofNullable(newLocation), this, setSpawn);
-        Sponge.getGame().getEventManager().post(post);
+        Sponge.getEventManager().post(post);
         if (post.isCancelled()) {
             return;
         }

--- a/src/main/java/org/spongepowered/mod/mixin/core/event/player/MixinPlayerSleepInBedEvent.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/event/player/MixinPlayerSleepInBedEvent.java
@@ -1,0 +1,55 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.mod.mixin.core.event.player;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.util.BlockPos;
+import net.minecraftforge.event.entity.player.PlayerSleepInBedEvent;
+import org.spongepowered.api.block.BlockSnapshot;
+import org.spongepowered.api.event.action.SleepingEvent;
+import org.spongepowered.api.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(value = PlayerSleepInBedEvent.class, remap = false)
+public abstract class MixinPlayerSleepInBedEvent extends MixinEventPlayer implements SleepingEvent.Pre {
+
+    @Shadow public final BlockPos pos = null;
+    private BlockSnapshot bed;
+    
+    @Inject(method = "<init>", at = @At("RETURN"))
+    public void onConstructed(EntityPlayer player, BlockPos pos, CallbackInfo ci) {
+        this.bed = ((World) player.worldObj).createSnapshot(pos.getX(), pos.getY(), pos.getZ());
+    }
+    
+    @Override
+    public BlockSnapshot getBed() {
+        return this.bed;
+    }
+
+}


### PR DESCRIPTION
I couldn't implement `SleepingEvent.Post` with a Forge event mixin because it requires more data than `PlayerWakeUpEvent` gives, but I needed to use code more complex than `@Inject` allows, and Forge heavily modifies this method. `SleepingEvent.Tick` was implemented in SpongePowered/SpongeCommon#229.

Requires SpongePowered/SpongeCommon#283.