### PR TITLE
Stop the server on a mixin error in development

### DIFF
--- a/src/main/java/org/spongepowered/mod/SpongeCoremod.java
+++ b/src/main/java/org/spongepowered/mod/SpongeCoremod.java
@@ -116,10 +116,8 @@ public class SpongeCoremod implements IFMLLoadingPlugin {
 
     @Override
     public void injectData(Map<String, Object> data) {
-        if ((Boolean)data.get("runtimeDeobfuscationEnabled")) {
-            MixinEnvironment.getDefaultEnvironment()
-                    .registerErrorHandlerClass("org.spongepowered.mod.mixin.handler.MixinErrorHandler");
-        }
+        MixinEnvironment.getDefaultEnvironment()
+                .registerErrorHandlerClass("org.spongepowered.mod.mixin.handler.MixinErrorHandler");
     }
 
     @Override


### PR DESCRIPTION
Currently, any error thrown by Mixin will not stop the server when running in development. Instead, the exception will be caught by some part of Minecraft, or by FML. As a mixin error means that a class will have not have been modified properly, this usually leaves the server in a broken half-running state.

This PR modifies `SpongeCoremod` to always register `MixinErrorHandler`, which now exits immediately when running in development.

Pinging @SpongePowered/developers for feedback.