### PR TITLE
Refactor IP Forwarding support to allow a LoginProfile property to define the FML marker.

### DIFF
--- a/src/main/java/org/spongepowered/mod/SpongeCoremod.java
+++ b/src/main/java/org/spongepowered/mod/SpongeCoremod.java
@@ -85,6 +85,7 @@ public class SpongeCoremod implements IFMLLoadingPlugin {
                 .addConfiguration("mixins.common.timings.json")
                 .addConfiguration("mixins.forge.core.json")
                 .addConfiguration("mixins.forge.entityactivation.json")
+                .addConfiguration("mixins.forge.bungeecord.json")
                 .registerTokenProviderClass("org.spongepowered.mod.SpongeCoremod$TokenProvider");
 
         // Classloader exclusions - TODO: revise when event pkg refactor reaches impl

--- a/src/main/java/org/spongepowered/mod/mixin/bungee/network/MixinNetHandlerHandshakeTCP.java
+++ b/src/main/java/org/spongepowered/mod/mixin/bungee/network/MixinNetHandlerHandshakeTCP.java
@@ -1,0 +1,67 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.mod.mixin.bungee.network;
+
+import com.mojang.authlib.properties.Property;
+import net.minecraft.network.EnumConnectionState;
+import net.minecraft.network.NetworkManager;
+import net.minecraft.network.handshake.client.C00Handshake;
+import net.minecraft.server.network.NetHandlerHandshakeTCP;
+import net.minecraftforge.fml.common.FMLCommonHandler;
+import net.minecraftforge.fml.common.network.NetworkRegistry;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.common.interfaces.IMixinNetworkManager;
+
+/**
+ * @author dualspiral
+ *
+ * Mixin that manually tells Forge that the user that is connecting is a Forge client, based on an entry in the
+ * login profile.
+ */
+@Mixin(value = NetHandlerHandshakeTCP.class)
+public abstract class MixinNetHandlerHandshakeTCP {
+
+    @Redirect(method = "processHandshake", at = @At(value = "INVOKE", target = "Lnet/minecraftforge/fml/common/FMLCommonHandler;handleServerHandshake"
+        + "(Lnet/minecraft/network/handshake/client/C00Handshake;Lnet/minecraft/network/NetworkManager;)Z", ordinal = 0, remap = false))
+    public boolean redirectFmlCheck(FMLCommonHandler handler, C00Handshake packetIn, NetworkManager networkManager) {
+        // Don't bother if the player is not allowed to log in.
+        if (handler.shouldAllowPlayerLogins() && packetIn.getRequestedState() == EnumConnectionState.LOGIN) {
+            Property[] pr = ((IMixinNetworkManager) networkManager).getSpoofedProfile();
+            if (pr != null) {
+                for (Property p : pr) {
+                    if (p.getName().equalsIgnoreCase("forgeClient") && p.getValue().equalsIgnoreCase("true")) {
+                        // Manually tell the system that we're a FML client.
+                        networkManager.channel().attr(NetworkRegistry.FML_MARKER).set(true);
+                        return true;
+                    }
+                }
+            }
+        }
+
+        return handler.handleServerHandshake(packetIn, networkManager);
+    }
+}

--- a/src/main/java/org/spongepowered/mod/mixin/plugin/bungee/BungeePlugin.java
+++ b/src/main/java/org/spongepowered/mod/mixin/plugin/bungee/BungeePlugin.java
@@ -1,0 +1,75 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.mod.mixin.plugin.bungee;
+
+import org.spongepowered.asm.lib.tree.ClassNode;
+import org.spongepowered.asm.mixin.extensibility.IMixinConfigPlugin;
+import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
+import org.spongepowered.common.SpongeImpl;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+public class BungeePlugin implements IMixinConfigPlugin {
+
+    private List<String> mixins = new ArrayList<>();
+
+    @Override
+    public void onLoad(String mixinPackage) {
+    }
+
+    @Override
+    public String getRefMapperConfig() {
+        return null;
+    }
+
+    @Override
+    public boolean shouldApplyMixin(String targetClassName, String mixinClassName) {
+        if (!SpongeImpl.getGlobalConfig().getConfig().getModules().usePluginBungeeCord()
+                && mixinClassName.contains("mixin.bungee")) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public void acceptTargets(Set<String> myTargets, Set<String> otherTargets) {
+    }
+
+    @Override
+    public List<String> getMixins() {
+        return this.mixins;
+    }
+
+    @Override
+    public void preApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {
+    }
+
+    @Override
+    public void postApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {
+    }
+}

--- a/src/main/resources/mixins.forge.bungeecord.json
+++ b/src/main/resources/mixins.forge.bungeecord.json
@@ -1,0 +1,8 @@
+{
+  "package": "org.spongepowered.mod.mixin.bungee",
+  "plugin": "org.spongepowered.mod.mixin.plugin.bungee.BungeePlugin",
+  "refmap": "mixins.forge.refmap.json",
+  "mixins": [
+    "network.MixinNetHandlerHandshakeTCP"
+  ]
+}


### PR DESCRIPTION
This allows Sponge to look for a "forgeClient" property in the LoginProfile that is forwarded by Bungee, in order to check whether the connecting client has Forge installed.

The previous method for IP forwarding has not been removed and so backwards compatibilty will remain.

Context for this change: https://github.com/SpigotMC/BungeeCord/pull/1557#issuecomment-158671754
Related SpongeCommon PR: https://github.com/SpongePowered/SpongeCommon/pull/278

Patched BungeeCord jar that supports this change: https://dl.dropboxusercontent.com/u/28705212/BungeeCord-LoginProfile.jar