### PR TITLE
Force com.typesafe:config:1.3.0 to resolve

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -85,6 +85,12 @@ shadowJar {
     }
 }
 
+configurations.all {
+    resolutionStrategy {
+        force 'com.typesafe:config:1.3.0'
+    }
+}
+
 copySrgs << {
     def file = project.file('build/srgs/mcp-srg.srg')
     file.append project.file('extraSrg.srg').text


### PR DESCRIPTION
This _should_ fix the issue with Eclipse. If someone could pull this down and see if it's resolved, that'd be great.