### PR TITLE
Add ItemStacks to interact events.

### DIFF
--- a/src/main/java/org/spongepowered/mod/mixin/core/event/player/MixinEventPlayerInteractBlock.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/event/player/MixinEventPlayerInteractBlock.java
@@ -37,6 +37,7 @@ import org.spongepowered.api.block.BlockTypes;
 import org.spongepowered.api.event.Event;
 import org.spongepowered.api.event.SpongeEventFactory;
 import org.spongepowered.api.event.block.InteractBlockEvent;
+import org.spongepowered.api.event.cause.Cause;
 import org.spongepowered.api.util.Direction;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
 import org.spongepowered.api.world.Location;
@@ -49,7 +50,6 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.common.registry.provider.DirectionFacingProvider;
 import org.spongepowered.common.util.StaticMixinHelper;
 import org.spongepowered.common.util.VecHelper;
-import org.spongepowered.mod.util.StaticMixinForgeHelper;
 
 import java.util.Optional;
 
@@ -110,12 +110,16 @@ public abstract class MixinEventPlayerInteractBlock extends MixinEventPlayer imp
 
     @Override
     public Event createSpongeEvent() {
+        Cause cause = getCause();
+        if(StaticMixinHelper.prePacketProcessItem != null){
+            cause = cause.with(StaticMixinHelper.prePacketProcessItem);
+        }
         if (action == Action.LEFT_CLICK_BLOCK) {
-            return SpongeEventFactory.createInteractBlockEventPrimary(getCause(), getInteractionPoint(), getTargetBlock(), getTargetSide());
+            return SpongeEventFactory.createInteractBlockEventPrimary(cause, getInteractionPoint(), getTargetBlock(), getTargetSide());
         } else if (action == Action.RIGHT_CLICK_AIR) {
-            return SpongeEventFactory.createInteractBlockEventSecondary(getCause(), getInteractionPoint(), getTargetBlock().withState(BlockTypes.AIR.getDefaultState()), getTargetSide());
+            return SpongeEventFactory.createInteractBlockEventSecondary(cause, getInteractionPoint(), getTargetBlock().withState(BlockTypes.AIR.getDefaultState()), getTargetSide());
         } else {
-            return SpongeEventFactory.createInteractBlockEventSecondary(getCause(), getInteractionPoint(), getTargetBlock(), getTargetSide());
+            return SpongeEventFactory.createInteractBlockEventSecondary(cause, getInteractionPoint(), getTargetBlock(), getTargetSide());
         }
     }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/event/player/MixinEventPlayerInteractEntity.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/event/player/MixinEventPlayerInteractEntity.java
@@ -37,6 +37,7 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.common.util.StaticMixinHelper;
 import org.spongepowered.mod.mixin.core.event.entity.MixinEventEntity;
 
 import java.util.Optional;
@@ -52,6 +53,9 @@ public abstract class MixinEventPlayerInteractEntity extends MixinEventEntity im
     @Inject(method = "<init>", at = @At("RETURN"))
     private void onConstruct(CallbackInfo callbackInfo) {
         this.cause = Cause.of(NamedCause.source(((EntityEvent) (Object) this).entity));
+        if(StaticMixinHelper.prePacketProcessItem != null){
+            this.cause = this.cause.with(StaticMixinHelper.prePacketProcessItem);
+        }
     }
 
     @Override


### PR DESCRIPTION
This commit adds ItemStack Causes to Interact Events fired by the player.

The reasoning behind this, is by using this you can now filter based on itemstack, as well as preparing for mods / 1.9 where the slot that is causing the interact may not be the players currently held item.

Will probably require Vanilla to implement the equivalent of the forge changes, as well as a way to catch modded interactions before this is finished.