### PR TITLE
Fix mods using null to remove items after use

### DIFF
--- a/src/main/java/org/spongepowered/mod/mixin/core/event/inventory/MixinEventUseItemStack.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/event/inventory/MixinEventUseItemStack.java
@@ -95,6 +95,12 @@ public abstract class MixinEventUseItemStack extends MixinEventPlayer implements
 
         @Inject(method = "<init>", at = @At("RETURN"))
         public void onConstructed(EntityPlayer player, net.minecraft.item.ItemStack item, int duration, net.minecraft.item.ItemStack result, CallbackInfo ci) {
+            // some mods use null to clear the stack, proper way is to set stackSize to 0, so to be valid in Sponge
+            // convert this method to a Sponge compatible 0 stack.
+            if (result == null) {
+                result = item.copy();
+                result.stackSize = 0;
+            }
             this.itemResultSnapshot = ((ItemStack) (Object) result).createSnapshot();
             this.itemResultTransaction = new Transaction<>(this.itemResultSnapshot, this.itemResultSnapshot.copy());
         }


### PR DESCRIPTION
This solves an issue with the vials in Botania causing infinite duplication after their last use. The mod handles storing empty vials in a custom way and then returns null after the event to delete the item. This breaks the code because results are supposed to be non-null so snapshots can be created.

To solve this problem, I made the null item case be replaced with a copy that has a 0 stack size. Which should remove the item, while not requiring significant modifications to the way the snapshot transactions work.