### PR TITLE
Add the SpongeAPI dependency to the annotation processor.

### DIFF
--- a/src/main/java/org/spongepowered/mod/SpongeModPlatform.java
+++ b/src/main/java/org/spongepowered/mod/SpongeModPlatform.java
@@ -25,10 +25,7 @@
 
 package org.spongepowered.mod;
 
-import static org.spongepowered.common.SpongeImpl.API_ID;
-import static org.spongepowered.common.SpongeImpl.API_NAME;
 import static org.spongepowered.common.SpongeImpl.ECOSYSTEM_ID;
-import static org.spongepowered.common.SpongeImpl.ECOSYSTEM_NAME;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;

--- a/src/main/java/org/spongepowered/mod/guice/SpongeGuiceModule.java
+++ b/src/main/java/org/spongepowered/mod/guice/SpongeGuiceModule.java
@@ -66,7 +66,7 @@ public class SpongeGuiceModule extends AbstractModule {
         bind(Logger.class).toInstance(SpongeImpl.getLogger());
 
         bind(PluginContainer.class).annotatedWith(named(SpongeImpl.ECOSYSTEM_ID)).toInstance((PluginContainer) SpongeMod.instance);
-        bind(PluginContainer.class).annotatedWith(named(SpongeImpl.API_ID)).to(SpongeApiContainer.class).in(Scopes.SINGLETON);
+        bind(PluginContainer.class).annotatedWith(named(Platform.API_ID)).to(SpongeApiContainer.class).in(Scopes.SINGLETON);
         bind(PluginContainer.class).annotatedWith(named(SpongeImpl.GAME_ID)).toInstance((PluginContainer) Loader.instance().getMinecraftModContainer());
 
         bind(Game.class).to(SpongeModGame.class).in(Scopes.SINGLETON);


### PR DESCRIPTION
[SpongeAPI](https://github.com/SpongePowered/SpongeAPI/pull/1214) | [SpongeCommon](https://github.com/SpongePowered/SpongeCommon/pull/687) | **SpongeForge** | [SpongeVanilla](https://github.com/SpongePowered/SpongeVanilla/pull/238)

Allows SpongePowered/Ore#95 to be added without giving (most) plugin developers any additional work. This uses a dependency version range, so it will work with any SpongeAPI version that's guaranteed to be compatible.