### PR TITLE
Implemented Player chat simulation method. Adds SpongeAPI-#733

### DIFF
--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/player/MixinEntityPlayerMP.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/player/MixinEntityPlayerMP.java
@@ -52,7 +52,7 @@ public abstract class MixinEntityPlayerMP extends MixinEntityPlayer implements P
     }
 
     @Override
-    public MessageChannelEvent.Chat chat(Text message) {
+    public MessageChannelEvent.Chat simulateChat(Text message) {
         String messageRaw = SpongeTexts.toLegacy(message);
         ITextComponent itextcomponent = new TextComponentTranslation("chat.type.text", SpongeTexts.toComponent(getDisplayNameText()), net.minecraftforge.common.ForgeHooks.newChatWithLinks(messageRaw));
 

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/player/MixinEntityPlayerMP.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/player/MixinEntityPlayerMP.java
@@ -54,7 +54,7 @@ public abstract class MixinEntityPlayerMP extends MixinEntityPlayer implements P
     @Override
     public MessageChannelEvent.Chat simulateChat(Text message) {
         String messageRaw = SpongeTexts.toLegacy(message);
-        ITextComponent itextcomponent = new TextComponentTranslation("chat.type.text", SpongeTexts.toComponent(getDisplayNameText()), net.minecraftforge.common.ForgeHooks.newChatWithLinks(messageRaw));
+        TextComponentTranslation itextcomponent = new TextComponentTranslation("chat.type.text", SpongeTexts.toComponent(getDisplayNameText()), net.minecraftforge.common.ForgeHooks.newChatWithLinks(messageRaw));
 
         EntityPlayerMP thisPlayer = (EntityPlayerMP)(Object) this;
 
@@ -63,9 +63,8 @@ public abstract class MixinEntityPlayerMP extends MixinEntityPlayer implements P
 
         if (!MinecraftForge.EVENT_BUS.post(event)) {
             MessageChannelEvent.Chat spongeEvent = (MessageChannelEvent.Chat) event;
-            Text theMessage = spongeEvent.getMessage();
             if (!spongeEvent.isMessageCancelled()) {
-                spongeEvent.getChannel().ifPresent(channel -> channel.send(this, theMessage, ChatTypes.CHAT));
+                spongeEvent.getChannel().ifPresent(channel -> channel.send(this, spongeEvent.getMessage(), ChatTypes.CHAT));
             }
         }
 


### PR DESCRIPTION
[API](https://github.com/SpongePowered/SpongeAPI/pull/1283) | [Vanilla](https://github.com/SpongePowered/SpongeVanilla/pull/253) | [Forge](https://github.com/SpongePowered/SpongeForge/pull/712)

This PR adds a method to Player, that allows for the simulation of chat.

The exact reasoning of it can be seen in the corresponding issue, https://github.com/SpongePowered/SpongeAPI/issues/733

This method returns the event so that the plugin can see what modifications have been made by other plugins, and to see if it has been cancelled.

This has not been implemented in Common as SV/SF already has all chat handling separated. To put it in common would require moving all of the handling over to common.
