### PR TITLE
Implement ZombieData for Forge registries

### DIFF
--- a/src/main/java/org/spongepowered/mod/data/ForgeVillagerZombieProfessionValueProcessor.java
+++ b/src/main/java/org/spongepowered/mod/data/ForgeVillagerZombieProfessionValueProcessor.java
@@ -1,0 +1,56 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.mod.data;
+
+import net.minecraft.entity.monster.EntityZombie;
+import net.minecraftforge.fml.common.registry.VillagerRegistry;
+import org.spongepowered.api.data.type.Profession;
+import org.spongepowered.common.data.processor.value.entity.VillagerZombieProfessionValueProcessor;
+import org.spongepowered.mod.registry.SpongeForgeVillagerRegistry;
+
+import java.util.Optional;
+
+public class ForgeVillagerZombieProfessionValueProcessor extends VillagerZombieProfessionValueProcessor {
+
+    @Override
+    public int getPriority() {
+        return 200;
+    }
+
+    @Override
+    protected boolean set(EntityZombie container, Optional<Profession> value) {
+        VillagerRegistry.VillagerProfession forgeProf = null;
+        if (value.isPresent()) {
+            forgeProf = SpongeForgeVillagerRegistry.getProfession(value.get()).orElse(null);
+        }
+
+        container.setVillagerType(forgeProf);
+        return true;
+    }
+
+    @Override protected Optional<Optional<Profession>> getVal(EntityZombie container) {
+        return Optional.of(SpongeForgeVillagerRegistry.getProfession(container.getVillagerTypeForge()));
+    }
+}

--- a/src/main/java/org/spongepowered/mod/data/ForgeZombieDataProcessor.java
+++ b/src/main/java/org/spongepowered/mod/data/ForgeZombieDataProcessor.java
@@ -1,0 +1,79 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.mod.data;
+
+import com.google.common.collect.ImmutableMap;
+import net.minecraft.entity.monster.EntityZombie;
+import net.minecraftforge.fml.common.registry.VillagerRegistry;
+import org.spongepowered.api.data.key.Key;
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.data.type.Profession;
+import org.spongepowered.api.data.type.ZombieType;
+import org.spongepowered.api.data.type.ZombieTypes;
+import org.spongepowered.common.data.processor.data.entity.ZombieDataProcessor;
+import org.spongepowered.common.entity.EntityUtil;
+import org.spongepowered.mod.registry.SpongeForgeVillagerRegistry;
+
+import java.util.Map;
+import java.util.Optional;
+
+public class ForgeZombieDataProcessor extends ZombieDataProcessor {
+
+    @Override
+    public int getPriority() {
+        return 200;
+    }
+
+    @Override
+    protected boolean set(EntityZombie dataHolder, Map<Key<?>, Object> keyValues) {
+        ZombieType type = (ZombieType) keyValues.get(Keys.ZOMBIE_TYPE);
+        Profession prof = (Profession) keyValues.get(Keys.VILLAGER_ZOMBIE_PROFESSION);
+        // If It's a native type, just set it directly
+        if(EntityUtil.isNative(type, prof)) {
+            dataHolder.setZombieType(EntityUtil.toNative(type, prof));
+            return true;
+        }
+
+        Optional<VillagerRegistry.VillagerProfession> forgeProf = SpongeForgeVillagerRegistry.getProfession(prof);
+        if (forgeProf.isPresent()) {
+            dataHolder.setVillagerType(forgeProf.get());
+            return true;
+        }
+
+        return false;
+    }
+
+    @Override
+    protected Map<Key<?>, ?> getValues(EntityZombie dataHolder) {
+        VillagerRegistry.VillagerProfession forgeProf = dataHolder.getVillagerTypeForge();
+        if (forgeProf == null) {
+            ZombieType type = EntityUtil.typeFromNative(dataHolder.getZombieType());
+            return ImmutableMap.of(Keys.ZOMBIE_TYPE, type, Keys.VILLAGER_ZOMBIE_PROFESSION, Optional.empty());
+        }
+
+        return ImmutableMap.of(Keys.ZOMBIE_TYPE, ZombieTypes.VILLAGER,
+                Keys.VILLAGER_ZOMBIE_PROFESSION, SpongeForgeVillagerRegistry.getProfession(dataHolder.getVillagerTypeForge()));
+    }
+}

--- a/src/main/java/org/spongepowered/mod/data/ForgeZombieTypeValueProcessor.java
+++ b/src/main/java/org/spongepowered/mod/data/ForgeZombieTypeValueProcessor.java
@@ -1,0 +1,54 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.mod.data;
+
+import net.minecraft.entity.monster.EntityZombie;
+import org.spongepowered.api.data.type.ZombieType;
+import org.spongepowered.api.data.type.ZombieTypes;
+import org.spongepowered.common.data.processor.value.entity.ZombieTypeValueProcessor;
+import org.spongepowered.common.entity.EntityUtil;
+
+import java.util.Optional;
+
+public class ForgeZombieTypeValueProcessor extends ZombieTypeValueProcessor {
+
+    @Override
+    public int getPriority() {
+        return 200;
+    }
+
+    // Forge sets custom villagers == NORMAL, we need to account for that
+    @Override
+    protected Optional<ZombieType> getVal(EntityZombie container) {
+        net.minecraft.entity.monster.ZombieType nativeType = container.getZombieType();
+        if (nativeType == net.minecraft.entity.monster.ZombieType.NORMAL
+                && container.getVillagerTypeForge() != null) {
+            // Forge zombie, it's a villager
+            return Optional.of(ZombieTypes.VILLAGER);
+        }
+
+        return Optional.of(EntityUtil.typeFromNative(nativeType));
+    }
+}

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/living/MixinEntityZombie.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/living/MixinEntityZombie.java
@@ -1,0 +1,63 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.mod.mixin.core.entity.living;
+
+import net.minecraft.entity.monster.EntityZombie;
+import net.minecraftforge.fml.common.registry.VillagerRegistry;
+import org.spongepowered.api.data.manipulator.mutable.entity.ZombieData;
+import org.spongepowered.api.data.type.ZombieType;
+import org.spongepowered.api.data.type.ZombieTypes;
+import org.spongepowered.api.entity.living.monster.Zombie;
+import org.spongepowered.api.util.annotation.NonnullByDefault;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.common.data.manipulator.mutable.entity.SpongeZombieData;
+import org.spongepowered.common.entity.EntityUtil;
+import org.spongepowered.mod.registry.SpongeForgeVillagerRegistry;
+
+import java.util.Optional;
+
+import javax.annotation.Nullable;
+
+@NonnullByDefault
+@Mixin(value = EntityZombie.class, priority = 1001, remap = false)
+public abstract class MixinEntityZombie implements Zombie {
+
+    @Shadow @Nullable public abstract VillagerRegistry.VillagerProfession getVillagerTypeForge();
+    @Shadow @Nullable public abstract net.minecraft.entity.monster.ZombieType getZombieType();
+
+    // Changes method on Common mixin, to use Forge professions
+    @Override
+    public ZombieData getZombieData() {
+        VillagerRegistry.VillagerProfession forgeProf = getVillagerTypeForge();
+        if (forgeProf == null) {
+            ZombieType type = EntityUtil.typeFromNative(getZombieType());
+            return new SpongeZombieData(type, Optional.empty());
+        }
+        return new SpongeZombieData(ZombieTypes.VILLAGER,
+                SpongeForgeVillagerRegistry.getProfession(getVillagerTypeForge()));
+    }
+
+}

--- a/src/main/java/org/spongepowered/mod/registry/SpongeForgeModuleRegistry.java
+++ b/src/main/java/org/spongepowered/mod/registry/SpongeForgeModuleRegistry.java
@@ -24,13 +24,21 @@
  */
 package org.spongepowered.mod.registry;
 
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableZombieData;
+import org.spongepowered.api.data.manipulator.immutable.item.ImmutableSpawnableData;
+import org.spongepowered.api.data.manipulator.mutable.entity.ZombieData;
+import org.spongepowered.api.data.manipulator.mutable.item.SpawnableData;
 import org.spongepowered.api.data.property.block.LightEmissionProperty;
 import org.spongepowered.api.data.property.block.MatterProperty;
 import org.spongepowered.api.data.property.block.SolidCubeProperty;
 import org.spongepowered.api.extra.fluid.data.manipulator.immutable.ImmutableFluidTankData;
 import org.spongepowered.api.extra.fluid.data.manipulator.mutable.FluidTankData;
 import org.spongepowered.common.data.SpongeDataManager;
+import org.spongepowered.common.data.manipulator.immutable.entity.ImmutableSpongeZombieData;
 import org.spongepowered.common.data.manipulator.immutable.extra.ImmutableSpongeFluidTankData;
+import org.spongepowered.common.data.manipulator.immutable.item.ImmutableSpongeSpawnableData;
+import org.spongepowered.common.data.manipulator.mutable.entity.SpongeZombieData;
 import org.spongepowered.common.data.manipulator.mutable.extra.SpongeFluidTankData;
 import org.spongepowered.common.data.property.SpongePropertyRegistry;
 import org.spongepowered.common.registry.type.world.gen.PopulatorTypeRegistryModule;
@@ -39,6 +47,9 @@ import org.spongepowered.mod.data.ForgeFluidTankDataProcessor;
 import org.spongepowered.mod.data.ForgeLightEmissionPropertyStore;
 import org.spongepowered.mod.data.ForgeMatterPropertyStore;
 import org.spongepowered.mod.data.ForgeSolidCubePropertyStore;
+import org.spongepowered.mod.data.ForgeVillagerZombieProfessionValueProcessor;
+import org.spongepowered.mod.data.ForgeZombieDataProcessor;
+import org.spongepowered.mod.data.ForgeZombieTypeValueProcessor;
 import org.spongepowered.mod.util.StaticMixinForgeHelper;
 
 public class SpongeForgeModuleRegistry {
@@ -56,6 +67,13 @@ public class SpongeForgeModuleRegistry {
 
         dataRegistry.registerDualProcessor(FluidTankData.class, SpongeFluidTankData.class, ImmutableFluidTankData.class,
                 ImmutableSpongeFluidTankData.class, new ForgeFluidTankDataProcessor());
+
+        dataRegistry.registerDataProcessorAndImpl(ZombieData.class, SpongeZombieData.class, ImmutableZombieData.class,
+                ImmutableSpongeZombieData.class, new ForgeZombieDataProcessor());
+
+        // Value registration
+        dataRegistry.registerValueProcessor(Keys.ZOMBIE_TYPE, new ForgeZombieTypeValueProcessor());
+        dataRegistry.registerValueProcessor(Keys.VILLAGER_ZOMBIE_PROFESSION, new ForgeVillagerZombieProfessionValueProcessor());
 
         //Populator types
         PopulatorTypeRegistryModule populatorTypeModule = PopulatorTypeRegistryModule.getInstance();

--- a/src/main/resources/mixins.forge.core.json
+++ b/src/main/resources/mixins.forge.core.json
@@ -22,6 +22,7 @@
         "entity.ai.MixinEntityAIBase",
         "entity.item.MixinEntityItem",
         "entity.living.MixinEntityLivingBase",
+        "entity.living.MixinEntityZombie",
         "entity.player.MixinEntityPlayer",
         "entity.player.MixinEntityPlayerMP",
         "entity.vehicle.MixinEntityMinecart",


### PR DESCRIPTION
Common: SpongePowered/SpongeCommon#826
API: SpongePowered/SpongeAPI#1299

This changes the way the data processors work to use Forge's VillagerRegistry.

A note: When a vanilla profession is set on a zombie, NMS `ZombieType` will correspond to the correct profession name. However, when a mod profession is used, forge instead uses the `NORMAL` type - this also fixes this behaviour so that a zombie with a modded profession will still show as a `VILLAGER` zombie.