### PR TITLE
Generalize recipes and implement them

### DIFF
--- a/src/main/java/org/spongepowered/mod/mixin/core/common/MixinSpongeImplHooks.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/common/MixinSpongeImplHooks.java
@@ -43,20 +43,24 @@ import net.minecraft.world.WorldProvider;
 import net.minecraft.world.WorldServer;
 import net.minecraft.world.chunk.Chunk;
 import net.minecraft.world.storage.MapStorage;
+import net.minecraftforge.common.ForgeHooks;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.util.FakePlayer;
 import net.minecraftforge.event.entity.EntityJoinWorldEvent;
 import net.minecraftforge.fml.common.FMLCommonHandler;
+import org.spongepowered.api.item.inventory.ItemStack;
 import org.spongepowered.api.world.PortalAgent;
 import org.spongepowered.api.world.PortalAgentTypes;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
 import org.spongepowered.common.SpongeImplHooks;
+import org.spongepowered.common.item.inventory.util.ItemStackUtil;
 import org.spongepowered.common.registry.type.world.PortalAgentRegistryModule;
 import org.spongepowered.mod.interfaces.IMixinEventBus;
 import org.spongepowered.mod.util.StaticMixinForgeHelper;
 
 import java.util.Iterator;
+import java.util.Optional;
 
 import javax.annotation.Nullable;
 
@@ -210,5 +214,18 @@ public abstract class MixinSpongeImplHooks {
     @Overwrite
     public static MapStorage getWorldMapStorage(World world) {
         return world.getPerWorldStorage();
+    }
+
+    // Crafting
+
+    @Overwrite
+    public static Optional<ItemStack> getContainerItem(ItemStack itemStack) {
+        net.minecraft.item.ItemStack nmsStack = ItemStackUtil.toNative(itemStack);
+        net.minecraft.item.ItemStack nmsContainerStack = ForgeHooks.getContainerItem(nmsStack);
+
+        if(nmsContainerStack.isEmpty())
+            return Optional.empty();
+        else
+            return Optional.of(ItemStackUtil.fromNative(nmsContainerStack));
     }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/common/MixinSpongeImplHooks.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/common/MixinSpongeImplHooks.java
@@ -31,6 +31,7 @@ import net.minecraft.entity.EntityList;
 import net.minecraft.entity.EnumCreatureType;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.item.crafting.ShapedRecipes;
 import net.minecraft.launchwrapper.Launch;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
@@ -48,7 +49,11 @@ import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.util.FakePlayer;
 import net.minecraftforge.event.entity.EntityJoinWorldEvent;
 import net.minecraftforge.fml.common.FMLCommonHandler;
+import net.minecraftforge.oredict.RecipeSorter;
+import org.spongepowered.api.Sponge;
 import org.spongepowered.api.item.inventory.ItemStack;
+import org.spongepowered.api.item.recipe.crafting.CraftingRecipe;
+import org.spongepowered.api.item.recipe.crafting.ShapedCraftingRecipe;
 import org.spongepowered.api.world.PortalAgent;
 import org.spongepowered.api.world.PortalAgentTypes;
 import org.spongepowered.asm.mixin.Mixin;
@@ -227,5 +232,15 @@ public abstract class MixinSpongeImplHooks {
             return Optional.empty();
         else
             return Optional.of(ItemStackUtil.fromNative(nmsContainerStack));
+    }
+
+    @Overwrite
+    public static void onCraftingRecipeRegister(CraftingRecipe recipe) {
+        // Generate a unique name for this recipe and register it in the RecipeSorter
+        int index = Sponge.getRegistry().getCraftingRecipeRegistry().getRecipes().size() - 1;
+        String name = recipe.getClass().getCanonicalName() + "@" + index;
+        RecipeSorter.Category category = recipe instanceof ShapedRecipes && recipe instanceof ShapedCraftingRecipe
+                ? RecipeSorter.Category.SHAPED : RecipeSorter.Category.SHAPELESS;
+        RecipeSorter.register(name, recipe.getClass(), category, "");
     }
 }


### PR DESCRIPTION
[SpongeAPI](https://github.com/SpongePowered/SpongeAPI/pull/1449)|[SpongeCommon](https://github.com/SpongePowered/SpongeCommon/pull/1119)|*SpongeForge*

This is a WIP continuation of [kashike's PR](https://github.com/SpongePowered/SpongeAPI/pull/1098), with his consent.
It aims to generalize how recipes are registered and handled. Instead of checking the equality of the ingredients, it works by testing ingredient predicates. It also aims to let the user implement the recipe interfaces by themselves, making it, for example, possible to transfer NBT data from the ingredients to the result.
In this PR, `ItemStackSnapshot`s are used extensively. This is to prevent the user from modifying the original `ItemStack`. I could instead provide an `ItemStack#copy`, but that doesn't make it visually obvious the original item won't change.