### PR TITLE
Implemented getWorld into the LoadingTicket class

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "SpongeCommon"]
 	path = SpongeCommon
-	url = https://github.com/SpongePowered/SpongeCommon.git
-	branch = bleeding
+	url = https://github.com/DevOnTheRocks/SpongeCommon.git
+	branch = feature/loadingticket-world

--- a/src/main/java/org/spongepowered/mod/service/world/SpongeChunkTicketManager.java
+++ b/src/main/java/org/spongepowered/mod/service/world/SpongeChunkTicketManager.java
@@ -150,11 +150,13 @@ public class SpongeChunkTicketManager implements ChunkTicketManager {
         private PluginContainer plugin;
         private String pluginId;
         private ImmutableSet<Vector3i> chunkList;
+        private World world;
 
         private SpongeLoadingTicket(Ticket ticket) {
             this.forgeTicket = ticket;
             this.plugin = SpongeImpl.getGame().getPluginManager().getPlugin(ticket.getModId()).get();
             this.pluginId = this.plugin.getId();
+            this.world = (World) ticket.world;
         }
 
         @Override
@@ -175,6 +177,11 @@ public class SpongeChunkTicketManager implements ChunkTicketManager {
         @Override
         public int getMaxNumChunks() {
             return this.forgeTicket.getMaxChunkListDepth();
+        }
+
+        @Override
+        public World getWorld() {
+            return this.world;
         }
 
         @Override


### PR DESCRIPTION
The SpongeForge implementation currently does not provide a way for the ticket to provide the world from the ticket, despite having provided it during the creation of the ticket. Forge supports this, so this is essentially just adding to the completion of the Forge Chunk Manager wrapper.

This is paired with my SpongeAPI pull request [#1479](https://github.com/SpongePowered/SpongeAPI/pull/1479)