### PR TITLE
Implementation for local server and client

### DIFF
--- a/src/main/java/org/spongepowered/mod/SpongeModGame.java
+++ b/src/main/java/org/spongepowered/mod/SpongeModGame.java
@@ -27,8 +27,11 @@ package org.spongepowered.mod;
 import static com.google.common.base.Preconditions.checkState;
 
 import com.google.inject.Singleton;
+import net.minecraft.client.Minecraft;
 import net.minecraft.server.MinecraftServer;
+import net.minecraftforge.fml.client.FMLClientHandler;
 import net.minecraftforge.fml.common.FMLCommonHandler;
+import org.spongepowered.api.Client;
 import org.spongepowered.api.GameDictionary;
 import org.spongepowered.api.Server;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
@@ -56,6 +59,21 @@ public final class SpongeModGame extends SpongeGame {
         final MinecraftServer server = FMLCommonHandler.instance().getSidedDelegate().getServer();
         checkState(server != null, "Server has not been initialized yet!");
         return (Server) server;
+    }
+
+    @Override
+    public boolean isClientAvailable() {
+        return this.getPlatform().getType().isClient() && FMLClientHandler.instance().getClient() != null;
+    }
+
+    @SuppressWarnings("LocalVariableDeclarationSideOnly")
+    @Override
+    public Client getClient() {
+        checkState(this.getPlatform().getType().isClient(), "Client is not available on this platform.");
+        final Minecraft mc = FMLClientHandler.instance().getClient();
+        checkState(mc != null, "Client has not been initialized yet!");
+        return (Client) mc;
+
     }
 
     @Override

--- a/src/main/java/org/spongepowered/mod/client/ClientTabList.java
+++ b/src/main/java/org/spongepowered/mod/client/ClientTabList.java
@@ -1,0 +1,80 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.mod.client;
+
+import net.minecraft.client.network.NetHandlerPlayClient;
+import org.spongepowered.api.entity.living.player.tab.TabList;
+import org.spongepowered.api.entity.living.player.tab.TabListEntry;
+import org.spongepowered.api.text.Text;
+
+import java.util.Collection;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+/**
+ * Created by Matthew on 4/18/2017.
+ */
+public class ClientTabList implements TabList {
+
+    private final NetHandlerPlayClient netHandler;
+
+    private Text header;
+    private Text footer;
+
+    public ClientTabList(NetHandlerPlayClient netHandler) {
+        this.netHandler = netHandler;
+    }
+
+    @Override
+    public Optional<Text> getHeader() {
+        return Optional.ofNullable(this.header);
+    }
+
+    public void setHeader(Text header) {
+        this.header = header;
+    }
+
+    @Override
+    public Optional<Text> getFooter() {
+        return Optional.ofNullable(this.footer);
+    }
+
+    public void setFooter(Text footer) {
+        this.footer = footer;
+    }
+
+    @Override
+    public Collection<TabListEntry> getEntries() {
+        return this.netHandler.getPlayerInfoMap().stream()
+                .map(TabListEntry.class::cast)
+                .collect(Collectors.toSet());
+    }
+
+    @Override
+    public Optional<TabListEntry> getEntry(UUID uniqueId) {
+        return Optional.ofNullable((TabListEntry) this.netHandler.getPlayerInfo(uniqueId));
+    }
+}

--- a/src/main/java/org/spongepowered/mod/client/interfaces/IMixinNetworkPlayerInfo.java
+++ b/src/main/java/org/spongepowered/mod/client/interfaces/IMixinNetworkPlayerInfo.java
@@ -1,0 +1,8 @@
+package org.spongepowered.mod.client.interfaces;
+
+import org.spongepowered.api.entity.living.player.tab.TabList;
+
+public interface IMixinNetworkPlayerInfo {
+
+    void setTabList(TabList tabList);
+}

--- a/src/main/java/org/spongepowered/mod/client/interfaces/IMixinNetworkPlayerInfo.java
+++ b/src/main/java/org/spongepowered/mod/client/interfaces/IMixinNetworkPlayerInfo.java
@@ -1,3 +1,27 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package org.spongepowered.mod.client.interfaces;
 
 import org.spongepowered.api.entity.living.player.tab.TabList;

--- a/src/main/java/org/spongepowered/mod/event/SpongeForgeEventFactory.java
+++ b/src/main/java/org/spongepowered/mod/event/SpongeForgeEventFactory.java
@@ -84,6 +84,7 @@ import org.spongepowered.api.block.tileentity.TileEntity;
 import org.spongepowered.api.data.Transaction;
 import org.spongepowered.api.entity.living.Living;
 import org.spongepowered.api.entity.living.player.Player;
+import org.spongepowered.api.entity.living.player.ServerPlayer;
 import org.spongepowered.api.entity.living.player.User;
 import org.spongepowered.api.event.Event;
 import org.spongepowered.api.event.SpongeEventFactory;
@@ -139,7 +140,6 @@ import org.spongepowered.common.interfaces.IMixinInitCause;
 import org.spongepowered.common.interfaces.entity.IMixinEntityLivingBase;
 import org.spongepowered.common.interfaces.world.IMixinLocation;
 import org.spongepowered.common.interfaces.world.IMixinWorld;
-import org.spongepowered.common.interfaces.world.IMixinWorldServer;
 import org.spongepowered.common.registry.provider.DirectionFacingProvider;
 import org.spongepowered.common.text.SpongeTexts;
 import org.spongepowered.common.util.VecHelper;
@@ -421,7 +421,7 @@ public class SpongeForgeEventFactory {
         formatter.getBody().add(new DefaultBodyApplier(chat[1]));
 
         Text rawSpongeMessage = Text.of(forgeEvent.getMessage());
-        MessageChannel originalChannel = channel = ((Player) forgeEvent.getPlayer()).getMessageChannel();
+        MessageChannel originalChannel = channel = ((ServerPlayer) forgeEvent.getPlayer()).getMessageChannel();
         MessageChannelEvent.Chat spongeEvent = SpongeEventFactory.createMessageChannelEventChat(Cause.source(forgeEvent.getPlayer()).build(), originalChannel, Optional.ofNullable(channel), formatter, rawSpongeMessage, false);
         return spongeEvent;
     }
@@ -788,7 +788,7 @@ public class SpongeForgeEventFactory {
     // Bulk Event Handling
     private static InteractBlockEvent createPlayerInteractEvent(Event event) {
         InteractBlockEvent spongeEvent = (InteractBlockEvent) event;
-        Player player = spongeEvent.getCause().first(Player.class).orElse(null);
+        ServerPlayer player = spongeEvent.getCause().first(ServerPlayer.class).orElse(null);
         // Forge doesn't support left-click AIR
         if (player == null || (spongeEvent instanceof InteractBlockEvent.Primary && spongeEvent.getTargetBlock() == BlockSnapshot.NONE)) {
             return spongeEvent;
@@ -1120,7 +1120,7 @@ public class SpongeForgeEventFactory {
 
     private static InteractEntityEvent.Secondary callEntityInteractEvent(Event event) {
         InteractEntityEvent.Secondary spongeEvent = (InteractEntityEvent.Secondary) event;
-        Optional<Player> player = spongeEvent.getCause().first(Player.class);
+        Optional<ServerPlayer> player = spongeEvent.getCause().first(ServerPlayer.class);
         if (!player.isPresent()) {
             return null;
         }

--- a/src/main/java/org/spongepowered/mod/mixin/core/client/MixinMinecraft.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/client/MixinMinecraft.java
@@ -41,6 +41,7 @@ import org.spongepowered.api.Client;
 import org.spongepowered.api.LocalServer;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.entity.living.player.ClientPlayer;
+import org.spongepowered.api.network.ServerConnection;
 import org.spongepowered.api.text.Text;
 import org.spongepowered.api.text.TranslatableText;
 import org.spongepowered.api.text.serializer.TextSerializers;
@@ -197,6 +198,14 @@ public abstract class MixinMinecraft implements Client, IMixinMinecraft {
     @Override
     public Optional<LocalServer> getLocalServer() {
         return Optional.ofNullable((LocalServer) this.theIntegratedServer);
+    }
+
+    @Override
+    public Optional<ServerConnection> getServerConnection() {
+        if (this.player != null) {
+            return Optional.of((ServerConnection) this.player.connection);
+        }
+        return Optional.empty();
     }
 
     @Override

--- a/src/main/java/org/spongepowered/mod/mixin/core/client/MixinMinecraft.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/client/MixinMinecraft.java
@@ -101,8 +101,7 @@ public abstract class MixinMinecraft implements Client, IMixinMinecraft {
         this.isNewSave = true;
     }
 
-    @Redirect(method = "launchIntegratedServer", at = @At(value = "FIELD", opcode = Opcodes.PUTFIELD,
-            target = "Lnet/minecraft/client/Minecraft;theIntegratedServer:Lnet/minecraft/server/integrated/IntegratedServer;", ordinal = 0))
+    @Redirect(method = "launchIntegratedServer", at = @At(value = "FIELD", opcode = Opcodes.PUTFIELD, target = "Lnet/minecraft/client/Minecraft;theIntegratedServer:Lnet/minecraft/server/integrated/IntegratedServer;", ordinal = 0))
     public void onSetIntegratedServerField(Minecraft minecraft, IntegratedServer server) {
         this.theIntegratedServer = server;
         if (this.isNewSave) {
@@ -131,7 +130,6 @@ public abstract class MixinMinecraft implements Client, IMixinMinecraft {
         this.kickMessage = text;
     }
 
-    @SuppressWarnings("UnresolvedMixinReference")
     @Inject(method = "shutdownMinecraftApplet", at = @At(value = "INVOKE", target = FORGE_TRANSFORMER_EXIT_VISITOR, remap = false))
     public void onShutdownDelegate(CallbackInfo ci) {
         SpongeImpl.postShutdownEvents();
@@ -167,7 +165,7 @@ public abstract class MixinMinecraft implements Client, IMixinMinecraft {
     }
 
     @SuppressWarnings("deprecation")
-    @Redirect(method = "loadWorld(Lnet/minecraft/client/multiplayer/WorldClient;Ljava/lang/String;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/"
+    @Redirect(method="loadWorld(Lnet/minecraft/client/multiplayer/WorldClient;Ljava/lang/String;)V", at = @At(value="INVOKE", target="Lnet/minecraft/"
             + "client/LoadingScreenRenderer;displayLoadingString(Ljava/lang/String;)V", ordinal = 0))
     public void onLoadWorld(LoadingScreenRenderer loadingScreen, String message) {
         // TODO Minecrell should review this...

--- a/src/main/java/org/spongepowered/mod/mixin/core/client/MixinMinecraft.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/client/MixinMinecraft.java
@@ -167,9 +167,8 @@ public abstract class MixinMinecraft implements Client, IMixinMinecraft {
     }
 
     @SuppressWarnings("deprecation")
-    @Redirect(method = "loadWorld(Lnet/minecraft/client/multiplayer/WorldClient;Ljava/lang/String;)V",
-            at = @At(value = "INVOKE", target = "Lnet/minecraft/"
-                    + "client/LoadingScreenRenderer;displayLoadingString(Ljava/lang/String;)V", ordinal = 0))
+    @Redirect(method = "loadWorld(Lnet/minecraft/client/multiplayer/WorldClient;Ljava/lang/String;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/"
+            + "client/LoadingScreenRenderer;displayLoadingString(Ljava/lang/String;)V", ordinal = 0))
     public void onLoadWorld(LoadingScreenRenderer loadingScreen, String message) {
         // TODO Minecrell should review this...
         if (this.kickMessage == null) {
@@ -177,9 +176,8 @@ public abstract class MixinMinecraft implements Client, IMixinMinecraft {
         } else {
             String loadingString;
             if (this.kickMessage instanceof TranslatableText) {
-                loadingString =
-                        ((TranslatableText) this.kickMessage).getTranslation().get(Locale.forLanguageTag(this.mcLanguageManager.getCurrentLanguage()
-                                .getLanguageCode()));
+                loadingString = ((TranslatableText) this.kickMessage).getTranslation().get(Locale.forLanguageTag(this.mcLanguageManager.getCurrentLanguage()
+                        .getLanguageCode()));
             } else {
                 loadingString = TextSerializers.LEGACY_FORMATTING_CODE.serialize(this.kickMessage);
             }
@@ -190,17 +188,17 @@ public abstract class MixinMinecraft implements Client, IMixinMinecraft {
 
     @Override
     public Optional<World> getLoadedWorld() {
-        return Optional.ofNullable((World) world);
+        return Optional.ofNullable((World) this.world);
     }
 
     @Override
     public Optional<ClientPlayer> getClientPlayer() {
-        return Optional.ofNullable((ClientPlayer) player);
+        return Optional.ofNullable((ClientPlayer) this.player);
     }
 
     @Override
     public Optional<LocalServer> getLocalServer() {
-        return Optional.ofNullable((LocalServer) theIntegratedServer);
+        return Optional.ofNullable((LocalServer) this.theIntegratedServer);
     }
 
     @Override
@@ -225,18 +223,18 @@ public abstract class MixinMinecraft implements Client, IMixinMinecraft {
         ServerData serverData = new ServerData("Sponge API Call", host + ":" + port, false);
 
         // connect to the server
-        FMLClientHandler.instance().connectToServer(currentScreen, serverData);
+        FMLClientHandler.instance().connectToServer(this.currentScreen, serverData);
 
     }
 
     @Override
     public Path getResourcePacksDirectory() {
-        return fileResourcepacks.toPath();
+        return this.fileResourcepacks.toPath();
     }
 
     @Override
     public Path getAssetsDirectory() {
-        return fileAssets.toPath();
+        return this.fileAssets.toPath();
     }
 
     @Override

--- a/src/main/java/org/spongepowered/mod/mixin/core/client/entity/MixinAbstractClientPlayer.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/client/entity/MixinAbstractClientPlayer.java
@@ -1,0 +1,31 @@
+package org.spongepowered.mod.mixin.core.client.entity;
+
+import net.minecraft.client.entity.AbstractClientPlayer;
+import net.minecraft.client.network.NetworkPlayerInfo;
+import net.minecraft.entity.player.EntityPlayer;
+import org.spongepowered.api.data.type.SkinPart;
+import org.spongepowered.api.entity.living.player.ClientPlayer;
+import org.spongepowered.api.entity.living.player.tab.TabListEntry;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.common.mixin.core.entity.player.MixinEntityPlayer;
+import org.spongepowered.common.util.SkinUtil;
+
+import java.util.Optional;
+import java.util.Set;
+
+@Mixin(AbstractClientPlayer.class)
+public abstract class MixinAbstractClientPlayer extends MixinEntityPlayer implements ClientPlayer {
+
+    @Shadow private NetworkPlayerInfo playerInfo;
+
+    @Override
+    public Set<SkinPart> getDisplayedSkinParts() {
+        return SkinUtil.fromFlags(this.dataManager.get(EntityPlayer.PLAYER_MODEL_FLAG));
+    }
+
+    @Override
+    public Optional<TabListEntry> getPlayerInfo() {
+        return Optional.ofNullable((TabListEntry) this.playerInfo);
+    }
+}

--- a/src/main/java/org/spongepowered/mod/mixin/core/client/entity/MixinAbstractClientPlayer.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/client/entity/MixinAbstractClientPlayer.java
@@ -1,3 +1,27 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package org.spongepowered.mod.mixin.core.client.entity;
 
 import net.minecraft.client.entity.AbstractClientPlayer;

--- a/src/main/java/org/spongepowered/mod/mixin/core/client/network/MixinNetworkPlayerInfo.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/client/network/MixinNetworkPlayerInfo.java
@@ -1,0 +1,82 @@
+package org.spongepowered.mod.mixin.core.client.network;
+
+import net.minecraft.client.network.NetworkPlayerInfo;
+import net.minecraft.util.text.ITextComponent;
+import net.minecraft.world.GameType;
+import org.spongepowered.api.entity.living.player.gamemode.GameMode;
+import org.spongepowered.api.entity.living.player.tab.TabList;
+import org.spongepowered.api.entity.living.player.tab.TabListEntry;
+import org.spongepowered.api.profile.GameProfile;
+import org.spongepowered.api.text.Text;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.common.text.SpongeTexts;
+import org.spongepowered.mod.client.interfaces.IMixinNetworkPlayerInfo;
+
+import java.util.Optional;
+
+import javax.annotation.Nullable;
+
+@Mixin(NetworkPlayerInfo.class)
+public class MixinNetworkPlayerInfo implements TabListEntry, IMixinNetworkPlayerInfo {
+
+    @Shadow @Final private com.mojang.authlib.GameProfile gameProfile;
+
+    @Shadow @Nullable private ITextComponent displayName;
+    @Shadow private int responseTime;
+    @Shadow private GameType gameType;
+
+    private TabList tabList;
+
+    @Override
+    public void setTabList(TabList tabList) {
+        this.tabList = tabList;
+    }
+
+    @Override
+    public TabList getList() {
+        return this.tabList;
+    }
+
+    @Override
+    public GameProfile getProfile() {
+        return (GameProfile) this.gameProfile;
+    }
+
+    @Override
+    public Optional<Text> getDisplayName() {
+        if (this.displayName == null) {
+            return Optional.empty();
+        }
+        return Optional.of(SpongeTexts.toText(this.displayName));
+    }
+
+    @Override
+    public TabListEntry setDisplayName(@Nullable Text displayName) {
+        this.displayName = displayName == null ? null : SpongeTexts.toComponent(displayName);
+        return this;
+    }
+
+    @Override
+    public int getLatency() {
+        return this.responseTime;
+    }
+
+    @Override
+    public TabListEntry setLatency(int latency) {
+        this.responseTime = latency;
+        return this;
+    }
+
+    @Override
+    public GameMode getGameMode() {
+        return (GameMode) (Object) this.gameType;
+    }
+
+    @Override
+    public TabListEntry setGameMode(GameMode gameMode) {
+        this.gameType = (GameType) (Object) gameMode;
+        return this;
+    }
+}

--- a/src/main/java/org/spongepowered/mod/mixin/core/client/network/MixinNetworkPlayerInfo.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/client/network/MixinNetworkPlayerInfo.java
@@ -1,3 +1,27 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package org.spongepowered.mod.mixin.core.client.network;
 
 import net.minecraft.client.network.NetworkPlayerInfo;

--- a/src/main/java/org/spongepowered/mod/mixin/core/client/server/MixinIntegratedServer.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/client/server/MixinIntegratedServer.java
@@ -30,8 +30,11 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiMainMenu;
 import net.minecraft.client.multiplayer.WorldClient;
 import net.minecraft.server.integrated.IntegratedServer;
+import net.minecraft.world.GameType;
 import net.minecraft.world.WorldSettings;
 import net.minecraft.world.WorldType;
+import org.spongepowered.api.LocalServer;
+import org.spongepowered.api.entity.living.player.gamemode.GameMode;
 import org.spongepowered.api.text.Text;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
 import org.spongepowered.asm.mixin.Final;
@@ -40,13 +43,18 @@ import org.spongepowered.asm.mixin.Overwrite;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.common.interfaces.IMixinIntegratedServer;
 import org.spongepowered.common.mixin.core.server.MixinMinecraftServer;
+import org.spongepowered.common.registry.type.entity.GameModeRegistryModule;
 import org.spongepowered.mod.client.interfaces.IMixinMinecraft;
 
 @NonnullByDefault
 @Mixin(IntegratedServer.class)
-public abstract class MixinIntegratedServer extends MixinMinecraftServer implements IMixinIntegratedServer {
+public abstract class MixinIntegratedServer extends MixinMinecraftServer implements IMixinIntegratedServer, LocalServer {
     @Shadow @Final private WorldSettings theWorldSettings;
     @Shadow @Final private Minecraft mc;
+    @Shadow private boolean isPublic;
+
+    @Shadow public abstract String shareToLAN(GameType type, boolean allowCheats);
+
     private boolean isNewSave;
 
     /**
@@ -100,5 +108,20 @@ public abstract class MixinIntegratedServer extends MixinMinecraftServer impleme
     @Override
     public boolean isNewSave() {
         return this.isNewSave;
+    }
+
+    @Override
+    public boolean isPublished() {
+        return this.isPublic;
+    }
+
+    @Override
+    public void publish(GameMode mode, boolean withCheats) {
+        this.shareToLAN(GameModeRegistryModule.toGameType(mode), withCheats);
+    }
+
+    @Override
+    public void publish() {
+        this.shareToLAN(mc.playerController.getCurrentGameType(), false);
     }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/client/server/MixinIntegratedServer.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/client/server/MixinIntegratedServer.java
@@ -122,6 +122,6 @@ public abstract class MixinIntegratedServer extends MixinMinecraftServer impleme
 
     @Override
     public void publish() {
-        this.shareToLAN(mc.playerController.getCurrentGameType(), false);
+        this.shareToLAN(this.mc.playerController.getCurrentGameType(), false);
     }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/fml/common/gameevent/MixinPlayerEvent.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/fml/common/gameevent/MixinPlayerEvent.java
@@ -28,7 +28,7 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraftforge.fml.common.gameevent.PlayerEvent;
 import org.spongepowered.api.entity.Transform;
-import org.spongepowered.api.entity.living.player.Player;
+import org.spongepowered.api.entity.living.player.ServerPlayer;
 import org.spongepowered.api.event.entity.living.humanoid.player.TargetPlayerEvent;
 import org.spongepowered.api.world.World;
 import org.spongepowered.asm.mixin.Final;
@@ -50,14 +50,14 @@ public abstract class MixinPlayerEvent extends MixinEvent implements TargetPlaye
     @Inject(method = "<init>", at = @At("RETURN"))
     public void onConstructed(EntityPlayer player, CallbackInfo ci) {
         if (player instanceof EntityPlayerMP) {
-            this.fromTransform = ((Player) player).getTransform();
-            this.toTransform = ((Player) player).getTransform();
+            this.fromTransform = ((ServerPlayer) player).getTransform();
+            this.toTransform = ((ServerPlayer) player).getTransform();
         }
     }
 
     @Override
-    public Player getTargetEntity() {
-        return (Player) this.player;
+    public ServerPlayer getTargetEntity() {
+        return (ServerPlayer) this.player;
     }
 
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/server/MixinIntegratedServerAnonInner3.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/server/MixinIntegratedServerAnonInner3.java
@@ -27,7 +27,7 @@ package org.spongepowered.mod.mixin.core.server;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
-import org.spongepowered.api.entity.living.player.Player;
+import org.spongepowered.api.entity.living.player.ServerPlayer;
 import org.spongepowered.api.event.SpongeEventFactory;
 import org.spongepowered.api.event.cause.Cause;
 import org.spongepowered.api.event.cause.NamedCause;
@@ -55,7 +55,7 @@ public class MixinIntegratedServerAnonInner3 {
     @ModifyArg(method = "run()V", at = @At(value = "INVOKE",
             target = "Lnet/minecraft/server/management/PlayerList;playerLoggedOut(Lnet/minecraft/entity/player/EntityPlayerMP;)V"))
     public EntityPlayerMP beforeFirePlayerLoggedOut(EntityPlayerMP playerIn) {
-        Player player = (Player) playerIn;
+        ServerPlayer player = (ServerPlayer) playerIn;
         MessageChannel originalChannel = player.getMessageChannel();
         ClientConnectionEvent.Disconnect event = SpongeEventFactory.createClientConnectionEventDisconnect(
                 Cause.of(NamedCause.source(player)), originalChannel, Optional.of(originalChannel), new MessageEvent.MessageFormatter(), player, true

--- a/src/main/java/org/spongepowered/mod/network/SpongeIndexedMessageChannel.java
+++ b/src/main/java/org/spongepowered/mod/network/SpongeIndexedMessageChannel.java
@@ -32,7 +32,7 @@ import io.netty.channel.ChannelHandler;
 import net.minecraftforge.fml.common.network.FMLEmbeddedChannel;
 import net.minecraftforge.fml.relauncher.Side;
 import org.spongepowered.api.Platform;
-import org.spongepowered.api.entity.living.player.Player;
+import org.spongepowered.api.entity.living.player.ServerPlayer;
 import org.spongepowered.api.network.ChannelBinding;
 import org.spongepowered.api.network.ChannelRegistrar;
 import org.spongepowered.api.network.Message;
@@ -108,7 +108,7 @@ class SpongeIndexedMessageChannel extends SpongeModChannelBinding implements Cha
     }
 
     @Override
-    public void sendTo(Player player, Message message) {
+    public void sendTo(ServerPlayer player, Message message) {
         super.sendTo(player, checkMessage(message));
     }
 

--- a/src/main/java/org/spongepowered/mod/network/SpongeModChannelBinding.java
+++ b/src/main/java/org/spongepowered/mod/network/SpongeModChannelBinding.java
@@ -34,7 +34,7 @@ import net.minecraftforge.fml.common.network.FMLEmbeddedChannel;
 import net.minecraftforge.fml.common.network.FMLOutboundHandler;
 import net.minecraftforge.fml.common.network.NetworkRegistry;
 import net.minecraftforge.fml.relauncher.Side;
-import org.spongepowered.api.entity.living.player.Player;
+import org.spongepowered.api.entity.living.player.ServerPlayer;
 import org.spongepowered.api.network.ChannelRegistrar;
 import org.spongepowered.api.plugin.PluginContainer;
 import org.spongepowered.common.network.SpongeNetworkManager.AbstractChannelBinding;
@@ -59,7 +59,7 @@ abstract class SpongeModChannelBinding extends AbstractChannelBinding {
         checkState(this.valid, "Channel bindng in invalid state (was it unbound?)");
     }
 
-    protected void sendTo(Player player, Object data) {
+    protected void sendTo(ServerPlayer player, Object data) {
         checkValidState();
         if (!((IMixinNetPlayHandler) ((EntityPlayerMP) player).connection).getRegisteredChannels().contains(getName())) {
             return; // Player doesn't accept this channel

--- a/src/main/java/org/spongepowered/mod/network/SpongeRawChannel.java
+++ b/src/main/java/org/spongepowered/mod/network/SpongeRawChannel.java
@@ -34,7 +34,7 @@ import io.netty.channel.ChannelHandler;
 import net.minecraft.network.PacketBuffer;
 import net.minecraftforge.fml.common.network.internal.FMLProxyPacket;
 import org.spongepowered.api.Platform;
-import org.spongepowered.api.entity.living.player.Player;
+import org.spongepowered.api.entity.living.player.ServerPlayer;
 import org.spongepowered.api.network.ChannelBinding;
 import org.spongepowered.api.network.ChannelBuf;
 import org.spongepowered.api.network.ChannelRegistrar;
@@ -99,7 +99,7 @@ public class SpongeRawChannel extends SpongeModChannelBinding implements Channel
     }
 
     @Override
-    public void sendTo(Player player, Consumer<ChannelBuf> payload) {
+    public void sendTo(ServerPlayer player, Consumer<ChannelBuf> payload) {
         super.sendTo(player, createPacket(payload));
     }
 

--- a/src/main/java/org/spongepowered/mod/service/world/SpongeChunkTicketManager.java
+++ b/src/main/java/org/spongepowered/mod/service/world/SpongeChunkTicketManager.java
@@ -36,7 +36,7 @@ import net.minecraftforge.common.ForgeChunkManager;
 import net.minecraftforge.common.ForgeChunkManager.Ticket;
 import org.spongepowered.api.data.DataContainer;
 import org.spongepowered.api.entity.Entity;
-import org.spongepowered.api.entity.living.player.Player;
+import org.spongepowered.api.entity.living.player.ServerPlayer;
 import org.spongepowered.api.plugin.PluginContainer;
 import org.spongepowered.api.world.ChunkTicketManager;
 import org.spongepowered.api.world.World;
@@ -82,7 +82,7 @@ public class SpongeChunkTicketManager implements ChunkTicketManager {
 
     @Override
     public Optional<PlayerLoadingTicket> createPlayerTicket(Object plugin, World world, UUID player) {
-        Optional<Player> spongePlayer = SpongeImpl.getGame().getServer().getPlayer(player);
+        Optional<ServerPlayer> spongePlayer = SpongeImpl.getGame().getServer().getPlayer(player);
         if (!spongePlayer.isPresent()) {
             return Optional.empty();
         }
@@ -99,7 +99,7 @@ public class SpongeChunkTicketManager implements ChunkTicketManager {
 
     @Override
     public Optional<PlayerEntityLoadingTicket> createPlayerEntityTicket(Object plugin, World world, UUID player) {
-        Optional<Player> spongePlayer = SpongeImpl.getGame().getServer().getPlayer(player);
+        Optional<ServerPlayer> spongePlayer = SpongeImpl.getGame().getServer().getPlayer(player);
         if (!spongePlayer.isPresent()) {
             return Optional.empty();
         }
@@ -126,7 +126,7 @@ public class SpongeChunkTicketManager implements ChunkTicketManager {
 
     @Override
     public int getAvailableTickets(UUID player) {
-        Optional<Player> spongePlayer = SpongeImpl.getGame().getServer().getPlayer(player);
+        Optional<ServerPlayer> spongePlayer = SpongeImpl.getGame().getServer().getPlayer(player);
         if (!spongePlayer.isPresent()) {
             return 0;
         }
@@ -345,7 +345,7 @@ public class SpongeChunkTicketManager implements ChunkTicketManager {
         public ListMultimap<String, Ticket> playerTicketsLoaded(ListMultimap<String, Ticket> tickets, net.minecraft.world.World world) {
             ListMultimap<UUID, LoadingTicket> spongeLoadingTickets = ArrayListMultimap.create();
             for (Map.Entry<String, Ticket> mapEntry : tickets.entries()) {
-                Optional<Player> player = SpongeImpl.getGame().getServer().getPlayer(mapEntry.getKey());
+                Optional<ServerPlayer> player = SpongeImpl.getGame().getServer().getPlayer(mapEntry.getKey());
                 if (player.isPresent()) {
                     spongeLoadingTickets.put(player.get().getUniqueId(), new SpongePlayerLoadingTicket(mapEntry.getValue()));
                 }
@@ -357,7 +357,7 @@ public class SpongeChunkTicketManager implements ChunkTicketManager {
             ListMultimap<String, Ticket> forgeTickets = ArrayListMultimap.create();
 
             for (Map.Entry<UUID, LoadingTicket> mapEntry : spongeKeptTickets.entries()) {
-                Optional<Player> player = SpongeImpl.getGame().getServer().getPlayer(mapEntry.getKey());
+                Optional<ServerPlayer> player = SpongeImpl.getGame().getServer().getPlayer(mapEntry.getKey());
                 if (player.isPresent()) {
                     forgeTickets.put(player.get().getName(), ((SpongeLoadingTicket) mapEntry.getValue()).forgeTicket);
                 }

--- a/src/main/resources/mixins.forge.core.json
+++ b/src/main/resources/mixins.forge.core.json
@@ -82,9 +82,11 @@
     ],
     "client": [
         "client.MixinMinecraft",
+        "client.entity.MixinAbstractClientPlayer",
         "client.gui.MixinGuiOverlayDebug",
         "client.multiplayer.MixinChunkProviderClient",
         "client.network.MixinNetHandlerPlayClient",
+        "client.network.MixinNetworkPlayerInfo",
         "client.server.MixinIntegratedServer",
         "server.MixinIntegratedServerAnonInner3"
     ],


### PR DESCRIPTION
[SpongeAPI](https://github.com/SpongePowered/SpongeAPI/pull/1540) | [**SpongeForge**](#)

Right now, `getClientPlayer()` will likely throw a class cast exception because `Player` is only mixined to `EntityPlayerMP` and not `AbstractClientPlayer` or its subclasses.