### PR TITLE
Prevent Sponge from setting the active mod container during async events

### DIFF
--- a/src/main/java/org/spongepowered/mod/event/SpongeModEventManager.java
+++ b/src/main/java/org/spongepowered/mod/event/SpongeModEventManager.java
@@ -301,10 +301,16 @@ public class SpongeModEventManager extends SpongeEventManager {
 
     @SuppressWarnings("unchecked")
     protected boolean post(Event event, List<RegisteredListener<?>> listeners, boolean beforeModifications, boolean forced) {
+        boolean isServerThread = SpongeImpl.getServer().isCallingFromMinecraftThread();
+
         ModContainer oldContainer = ((IMixinLoadController) SpongeMod.instance.getController()).getActiveModContainer();
         for (@SuppressWarnings("rawtypes")
         RegisteredListener listener : listeners) {
-            ((IMixinLoadController) SpongeMod.instance.getController()).setActiveModContainer((ModContainer) listener.getPlugin());
+            // If events are firing off the main thread, don't set this, as an event on the
+            // server thread might fire.
+            if (isServerThread) {
+                ((IMixinLoadController) SpongeMod.instance.getController()).setActiveModContainer((ModContainer) listener.getPlugin());
+            }
             try {
                 if (forced || (!listener.isBeforeModifications() && !beforeModifications)
                         || (listener.isBeforeModifications() && beforeModifications)) {
@@ -320,7 +326,9 @@ public class SpongeModEventManager extends SpongeEventManager {
                 CauseTracker.getInstance().getCurrentContext().activeContainer(null);
             }
         }
-        ((IMixinLoadController) SpongeMod.instance.getController()).setActiveModContainer(oldContainer);
+        if (isServerThread) {
+            ((IMixinLoadController) SpongeMod.instance.getController()).setActiveModContainer(oldContainer);
+        }
         return event instanceof Cancellable && ((Cancellable) event).isCancelled();
     }
 

--- a/src/main/java/org/spongepowered/mod/mixin/core/fml/common/MixinLoadController.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/fml/common/MixinLoadController.java
@@ -33,7 +33,9 @@ import org.spongepowered.api.plugin.PluginContainer;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import org.spongepowered.common.SpongeImpl;
 import org.spongepowered.mod.event.SpongeModEventManager;
 import org.spongepowered.mod.event.StateRegistry;
@@ -42,6 +44,8 @@ import org.spongepowered.mod.interfaces.IMixinLoadController;
 @Mixin(value = LoadController.class, remap = false)
 public abstract class MixinLoadController implements IMixinLoadController {
     @Shadow private ModContainer activeContainer;
+
+    @Shadow protected abstract ModContainer findActiveContainerFromStack();
 
     @Redirect(method = "distributeStateMessage", at = @At(value = "INVOKE", target = "Lcom/google/common/eventbus/EventBus;post(Ljava/lang/Object;)V", ordinal = 0, remap = false))
     public void onPost(EventBus eventBus, Object event, LoaderState state, Object[] eventData) {
@@ -64,5 +68,22 @@ public abstract class MixinLoadController implements IMixinLoadController {
     @Override
     public void setActiveModContainer(ModContainer container) {
         this.activeContainer = container;
+    }
+
+    /**
+     * @author dualspiral - 4th June 2017
+     *
+     * Sponge can post events from threads that are not on the server thread,
+     * and this can cause confusion for the majority of events that are
+     * firing on the server thread. In these cases, we just get the
+     * mod from the stack.
+     *
+     * @param cir
+     */
+    @Inject(method = "activeContainer", at = @At("HEAD"), cancellable = true)
+    private void onActiveContainerHead(CallbackInfoReturnable<ModContainer> cir) {
+        if (!SpongeImpl.getServer().isCallingFromMinecraftThread()) {
+            cir.setReturnValue(findActiveContainerFromStack());
+        }
     }
 }


### PR DESCRIPTION
[Original Issue](https://github.com/SpongePowered/SpongeForge/issues/1460) | [Relevant Comment](https://github.com/SpongePowered/SpongeForge/issues/1460#issuecomment-306061717)

See the original issue for context, specifically my comment. I'm looking for a review to just ensure that this isn't going to break mods badly - though my testing suggests it wouldn't, I feel like a second opinion is necessary.

This PR:

* Prevents the active mod container being set when an async event fires.
* Inject code into the head of `LoadController#activeContainer()` to always use the call stack to get the active plugin when called from an async thread.

This fixes #1460 from the Sponge end.