### PR TITLE
Fix lifespan being ignored when EntityItem Activation is enabled

### DIFF
--- a/src/main/java/org/spongepowered/mod/mixin/entityactivation/MixinEntityItem_Activation.java
+++ b/src/main/java/org/spongepowered/mod/mixin/entityactivation/MixinEntityItem_Activation.java
@@ -1,0 +1,59 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.mod.mixin.entityactivation;
+
+import net.minecraft.entity.item.EntityItem;
+import net.minecraft.item.ItemStack;
+import org.spongepowered.api.util.annotation.NonnullByDefault;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.common.interfaces.world.IMixinWorldServer;
+import org.spongepowered.common.mixin.entityactivation.MixinEntity_Activation;
+
+@NonnullByDefault
+@Mixin(EntityItem.class)
+public abstract class MixinEntityItem_Activation extends MixinEntity_Activation {
+
+    @Shadow public abstract ItemStack getItem();
+
+    @Shadow private int pickupDelay;
+    @Shadow private int age;
+    @Shadow public int lifespan;
+
+    @Override
+    public void inactiveTick() {
+        if (this.pickupDelay > 0 && this.pickupDelay != 32767) {
+            --this.pickupDelay;
+        }
+
+        if (!this.world.isRemote && this.lifespan == 6000) {
+            if (this.age >= ((IMixinWorldServer) this.world).getActiveConfig().getConfig().getEntity().getItemDespawnRate()) {
+                this.setDead();
+            }
+        } else if (!this.world.isRemote && this.age >= this.lifespan) {
+            this.setDead();
+        }
+    }
+}

--- a/src/main/resources/mixins.forge.entityactivation.json
+++ b/src/main/resources/mixins.forge.entityactivation.json
@@ -6,6 +6,7 @@
     "target": "@env(DEFAULT)",
     "compatibilityLevel": "JAVA_8",
     "server": [
+        "MixinEntityItem_Activation",
         "MixinWorld_Activation"
     ],
     "injectors": {


### PR DESCRIPTION
Forge adds a lifespan NBT tag allowing mods to set a longer despawn
delay than possible in Vanilla, Sponge previously ignored this when
ticking inactive items. This adds a check if items have the default
lifespan, fall back to the Sponge config for maximum age, otherwise use
the value set by mods.

Fixes https://github.com/SpongePowered/SpongeForge/issues/1324