### PR TITLE
Fix build.gradle using reference to rootProject.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -86,7 +86,7 @@ artifacts {
 
 allprojects {
     // Re-obfuscate only after creating the shadowDevJar
-    tasks.findByName('reobfJar')?.mustRunAfter rootProject.tasks.shadowDevJar
+    tasks.findByName('reobfJar')?.mustRunAfter this.tasks.shadowDevJar
 }
 
 tasks.withType(ShadowJar) {


### PR DESCRIPTION
Replace `rootProject` reference with `this` to make SpongeForge behave when it isn't the root project.
closes #2049 