### PR TITLE
Fix mixup in SpongeChunkTicketManager

### DIFF
--- a/src/main/java/org/spongepowered/mod/service/world/SpongeChunkTicketManager.java
+++ b/src/main/java/org/spongepowered/mod/service/world/SpongeChunkTicketManager.java
@@ -164,7 +164,7 @@ public class SpongeChunkTicketManager implements ChunkTicketManager {
 
         @Override
         public boolean setNumChunks(int numChunks) {
-            if (numChunks > getMaxTickets(this.plugin) || (numChunks <= 0 && getMaxTickets(this.plugin) > 0)) {
+            if (numChunks > getMaxNumChunks(this.plugin) || (numChunks <= 0 && getMaxNumChunks(this.plugin) > 0)) {
                 return false;
             }
 


### PR DESCRIPTION
check ChunkListDepth, to set ChunkListDepth and not the maximum ticket count