### PR TITLE
Add support for working around broken mods

### DIFF
--- a/src/main/java/org/spongepowered/mod/SpongeCoremod.java
+++ b/src/main/java/org/spongepowered/mod/SpongeCoremod.java
@@ -97,6 +97,7 @@ public class SpongeCoremod implements IFMLLoadingPlugin {
         }
 
         Mixins.addConfiguration("mixins.forge.core.json");
+        Mixins.addConfiguration("mixins.forge.brokenmods.json");
         Mixins.addConfiguration("mixins.forge.bungeecord.json");
         Mixins.addConfiguration("mixins.forge.entityactivation.json");
         Mixins.addConfiguration("mixins.forge.optimization.json");

--- a/src/main/java/org/spongepowered/mod/interfaces/IMixinFMLEventChannel.java
+++ b/src/main/java/org/spongepowered/mod/interfaces/IMixinFMLEventChannel.java
@@ -1,0 +1,34 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.mod.interfaces;
+
+import io.netty.channel.ChannelHandlerContext;
+import net.minecraftforge.fml.common.network.internal.FMLProxyPacket;
+
+public interface IMixinFMLEventChannel {
+
+    void spongeFireRead(FMLProxyPacket msg, ChannelHandlerContext ctx);
+
+}

--- a/src/main/java/org/spongepowered/mod/mixin/brokenmod/MixinSimpleNetworkWrapper.java
+++ b/src/main/java/org/spongepowered/mod/mixin/brokenmod/MixinSimpleNetworkWrapper.java
@@ -1,0 +1,60 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.mod.mixin.brokenmod;
+
+import net.minecraftforge.fml.common.Loader;
+import net.minecraftforge.fml.common.ModContainer;
+import net.minecraftforge.fml.common.network.simpleimpl.IMessageHandler;
+import net.minecraftforge.fml.common.network.simpleimpl.SimpleChannelHandlerWrapper;
+import net.minecraftforge.fml.common.network.simpleimpl.SimpleNetworkWrapper;
+import net.minecraftforge.fml.relauncher.Side;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.common.SpongeImpl;
+import org.spongepowered.mod.mixin.modfixer.BrokenModNetworkChannelWrapper;
+
+@Mixin(SimpleNetworkWrapper.class)
+public class MixinSimpleNetworkWrapper {
+
+    @SuppressWarnings("unchecked")
+    @Redirect(method = "getHandlerWrapper", at = @At(value = "NEW", target = "net/minecraftforge/fml/common/network/simpleimpl/SimpleChannelHandlerWrapper"))
+    private SimpleChannelHandlerWrapper<?, ?> onCreateChannelHandler(IMessageHandler<?, ?> messageHandler, Side side, Class<?> requestType) {
+        if (this.isEnabledForMod()) {
+            return new BrokenModNetworkChannelWrapper(messageHandler, side, requestType);
+        }
+        return new SimpleChannelHandlerWrapper(messageHandler, side, requestType);
+    }
+
+    private boolean isEnabledForMod() {
+        ModContainer container = Loader.instance().activeModContainer();
+        if (container == null) {
+            return false;
+        }
+        return SpongeImpl.getGlobalConfig().getConfig().getBrokenMods().getBrokenNetworkHandlerMods().contains(container.getModId());
+
+    }
+
+}

--- a/src/main/java/org/spongepowered/mod/mixin/brokenmod/MixinSimpleNetworkWrapper.java
+++ b/src/main/java/org/spongepowered/mod/mixin/brokenmod/MixinSimpleNetworkWrapper.java
@@ -36,7 +36,7 @@ import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.common.SpongeImpl;
 import org.spongepowered.mod.mixin.modfixer.BrokenModNetworkChannelWrapper;
 
-@Mixin(SimpleNetworkWrapper.class)
+@Mixin(value = SimpleNetworkWrapper.class, remap = false)
 public class MixinSimpleNetworkWrapper {
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/org/spongepowered/mod/mixin/modfixer/BrokenModNetworkChannelWrapper.java
+++ b/src/main/java/org/spongepowered/mod/mixin/modfixer/BrokenModNetworkChannelWrapper.java
@@ -1,0 +1,78 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.mod.mixin.modfixer;
+
+import io.netty.channel.ChannelHandlerContext;
+import net.minecraft.client.Minecraft;
+import net.minecraft.util.IThreadListener;
+import net.minecraftforge.fml.common.Loader;
+import net.minecraftforge.fml.common.ModContainer;
+import net.minecraftforge.fml.common.network.simpleimpl.IMessage;
+import net.minecraftforge.fml.common.network.simpleimpl.IMessageHandler;
+import net.minecraftforge.fml.common.network.simpleimpl.SimpleChannelHandlerWrapper;
+import net.minecraftforge.fml.relauncher.Side;
+import org.spongepowered.common.SpongeImpl;
+
+import java.util.function.Supplier;
+
+public class BrokenModNetworkChannelWrapper<REQ extends IMessage, REPLY extends IMessage> extends SimpleChannelHandlerWrapper<REQ, REPLY> {
+
+    private final Side sideFromSponge;
+    private Supplier<IThreadListener> scheduler;
+
+    public BrokenModNetworkChannelWrapper(Class<? extends IMessageHandler<? super REQ, ? extends REPLY>> handler, Side side, Class<REQ> requestType) {
+        super(handler, side, requestType);
+        this.sideFromSponge = side;
+        this.onInit();
+    }
+
+    public BrokenModNetworkChannelWrapper(IMessageHandler<? super REQ, ? extends REPLY> handler, Side side, Class<REQ> requestType) {
+        super(handler, side, requestType);
+        this.sideFromSponge = side;
+        this.onInit();
+    }
+
+    private void onInit() {
+        if (this.sideFromSponge == Side.CLIENT) {
+            Minecraft minecraft = Minecraft.getMinecraft();
+            scheduler = () -> minecraft;
+        } else {
+            // The server is likely not yet running when mods register their network handlers
+            scheduler = SpongeImpl::getServer;
+        }
+    }
+
+    @Override
+    protected void channelRead0(ChannelHandlerContext ctx, REQ msg) throws Exception {
+        this.scheduler.get().addScheduledTask(() -> {
+            try {
+                super.channelRead0(ctx, msg);
+            } catch (Exception e) {
+                throw new RuntimeException("Exception when invoking mod packet handler!", e);
+            }
+        });
+    }
+
+}

--- a/src/main/java/org/spongepowered/mod/mixin/plugin/brokenmod/BrokenModPlugin.java
+++ b/src/main/java/org/spongepowered/mod/mixin/plugin/brokenmod/BrokenModPlugin.java
@@ -1,0 +1,71 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.mod.mixin.plugin.brokenmod;
+
+import org.spongepowered.asm.lib.tree.ClassNode;
+import org.spongepowered.asm.mixin.extensibility.IMixinConfigPlugin;
+import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
+import org.spongepowered.common.SpongeImpl;
+
+import java.util.List;
+import java.util.Set;
+
+public class BrokenModPlugin implements IMixinConfigPlugin {
+
+    @Override
+    public void onLoad(String mixinPackage) {
+
+    }
+
+    @Override
+    public String getRefMapperConfig() {
+        return null;
+    }
+
+    @Override
+    public boolean shouldApplyMixin(String targetClassName, String mixinClassName) {
+        return SpongeImpl.getGlobalConfig().getConfig().getModules().useBrokenMods();
+    }
+
+    @Override
+    public void acceptTargets(Set<String> myTargets, Set<String> otherTargets) {
+
+    }
+
+    @Override
+    public List<String> getMixins() {
+        return null;
+    }
+
+    @Override
+    public void preApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {
+
+    }
+
+    @Override
+    public void postApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {
+
+    }
+}

--- a/src/main/java/org/spongepowered/mod/network/brokenmod/BrokenModSimpleChannelInboundHandlerWrapper.java
+++ b/src/main/java/org/spongepowered/mod/network/brokenmod/BrokenModSimpleChannelInboundHandlerWrapper.java
@@ -1,0 +1,70 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.mod.network.brokenmod;
+
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.SimpleChannelInboundHandler;
+import net.minecraftforge.fml.common.FMLCommonHandler;
+import net.minecraftforge.fml.common.FMLLog;
+import net.minecraftforge.fml.common.network.FMLEventChannel;
+import net.minecraftforge.fml.common.network.internal.FMLProxyPacket;
+import org.spongepowered.mod.interfaces.IMixinFMLEventChannel;
+
+@ChannelHandler.Sharable
+public class BrokenModSimpleChannelInboundHandlerWrapper extends SimpleChannelInboundHandler<FMLProxyPacket> {
+
+    private FMLEventChannel eventChannel;
+    private BrokenModData brokenModData;
+
+    public BrokenModSimpleChannelInboundHandlerWrapper(FMLEventChannel eventChannel) {
+        this.eventChannel = eventChannel;
+        this.brokenModData = new BrokenModData(() -> FMLCommonHandler.instance().getSide());
+    }
+
+    @Override
+    protected void channelRead0(ChannelHandlerContext ctx, FMLProxyPacket msg) throws Exception
+    {
+        this.brokenModData.schedule(() -> {
+            ((IMixinFMLEventChannel) eventChannel).spongeFireRead(msg,ctx);
+        });
+
+    }
+
+    @Override
+    public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception
+    {
+        this.brokenModData.schedule(() -> {
+            eventChannel.fireUserEvent(evt,ctx);
+        });
+    }
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception
+    {
+        FMLLog.log.error("Sponge BrokenModSimpleChannelInboundHandlerWrapper exception", cause);
+        super.exceptionCaught(ctx, cause);
+    }
+
+}

--- a/src/main/java/org/spongepowered/mod/util/StaticMixinForgeHelper.java
+++ b/src/main/java/org/spongepowered/mod/util/StaticMixinForgeHelper.java
@@ -46,6 +46,7 @@ import org.spongepowered.api.event.cause.entity.damage.DamageModifier;
 import org.spongepowered.api.event.cause.entity.damage.DamageModifierTypes;
 import org.spongepowered.api.item.inventory.ItemStackSnapshot;
 import org.spongepowered.api.item.inventory.equipment.EquipmentType;
+import org.spongepowered.common.SpongeImpl;
 import org.spongepowered.common.entity.SpongeEntityType;
 import org.spongepowered.common.event.damage.DamageEventHandler;
 import org.spongepowered.common.item.inventory.util.ItemStackUtil;
@@ -380,5 +381,12 @@ public final class StaticMixinForgeHelper {
             SpongeEntityType entityType = new SpongeEntityType(id, entityName, modId, entityClass, null);
             EntityTypeRegistryModule.getInstance().registerAdditionalCatalog(entityType);
         }
+    }
+
+    public static boolean shouldTakeOverModNetworking(ModContainer mod) {
+        if (mod == null) {
+            return false;
+        }
+        return SpongeImpl.getGlobalConfig().getConfig().getBrokenMods().getBrokenNetworkHandlerMods().contains(mod.getModId());
     }
 }

--- a/src/main/resources/mixins.forge.brokenmods.json
+++ b/src/main/resources/mixins.forge.brokenmods.json
@@ -1,0 +1,14 @@
+{
+  "minVersion": "0.7.10",
+  "package": "org.spongepowered.mod.mixin.brokenmod",
+  "refmap": "mixins.forge.refmap.json",
+  "plugin": "org.spongepowered.mod.mixin.plugin.brokenmod.BrokenModPlugin",
+  "target": "@env(DEFAULT)",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": [
+    "MixinSimpleNetworkWrapper"
+  ],
+  "injectors": {
+    "defaultRequire": 1
+  }
+}

--- a/src/main/resources/mixins.forge.brokenmods.json
+++ b/src/main/resources/mixins.forge.brokenmods.json
@@ -6,6 +6,7 @@
   "target": "@env(DEFAULT)",
   "compatibilityLevel": "JAVA_8",
   "mixins": [
+    "MixinFMLEventChannel",
     "MixinSimpleNetworkWrapper"
   ],
   "injectors": {


### PR DESCRIPTION
**SpongeForge** | [SpongeCommon](https://github.com/SpongePowered/SpongeCommon/pull/1991)

A large number of mods have improper network handlers. Instead of
interacting with the world from a task scheduled on the main thread,
they directly modify the world from a Netty handler. This is strictly
incorrect, and will cause issues even when Sponge is not installed.

However, due to the extra thread checks added by Sponge, mods which
*seem* to work correctly without Sponge can appear to break when it is
added. While the ultimate solution is always for the mod to only modify
the world from the main thread, mod developers don't always respond
quickly to these kinds of issues. The end result: while these kinds of
mods are broken even without Sponge, the extra checks done by Sponge
means that these mods may appear 'more broken' with Sponge installed.

As a temporary workaround to help server owners, this commit adds an
option to forcibly reschedule mod network handlers on the main thread.
To avoid messing with Netty directly, only mods using Forge's 'simple
channel' system are handled. While Forge technically provides other
channel options to mods, in practice virtually all mods use the 'simple
channel' system. Indeed, to date all issues opened on Sponge for these
misbehaving mods are caused by mods using the 'simple channel' system.

The implementation of this feature is minimally invasive - it substitues
a subclass of Forge's SimpleChannelHandlerWrapper when a mod registers
a 'simple channel' handler. However, to further minimize its impact,
this replacement is completely off by default - not even the mixin is
applied. Furthermore, this feature must be explicitly enabled for
specific mod ids via the config. Any mods not in the config will be
completely untouched.