### PR TITLE
Version change

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,15 +14,7 @@ pipeline {
             steps {
                 withCredentials([string(credentialsId: 'spongeMavenUsername', variable: 'spongeMavenUsername'), string(credentialsId: 'spongeMavenPassword', variable: 'spongeMavenPassword'), string(credentialsId: 'spongeIndexerUsername', variable: 'spongeIndexerUsername'), string(credentialsId: 'spongeIndexerPassword', variable: 'spongeIndexerPassword'), string(credentialsId: 'spongeKeyStore', variable: 'spongeKeyStore'), string(credentialsId: 'spongeKeyStoreAlias', variable: 'spongeKeyStoreAlias'), string(credentialsId: 'spongeKeyStorePass', variable: 'spongeKeyStorePass'), string(credentialsId: 'spongeKeyStorePass', variable: 'spongeKeyStoreKeyPass')]) {
 
-                    sh '''./gradlew --refresh-dependencies -s
-                    -PforgeJenkinsPass=${forgeJenkinsPass}
-                              -PspongeKeyStore=${spongeKeyStore}
-                              -PspongeKeyStoreAlias=${spongeKeyStoreAlias}
-                              -PspongeKeyStorePass=${spongeKeyStorePass}
-                              -PspongeKeyStoreKeyPass=${spongeKeyStoreKeyPass}
-                              -PspongeCertificateFingerprint=${spongeCertFingerprint}
-                              clean build changelog'
-                              '''
+                    sh '''./gradlew --refresh-dependencies -s -PforgeJenkinsPass=${forgeJenkinsPass} -PspongeKeyStore=${spongeKeyStore}  -PspongeKeyStoreAlias=${spongeKeyStoreAlias} -PspongeKeyStorePass=${spongeKeyStorePass} -PspongeKeyStoreKeyPass=${spongeKeyStoreKeyPass} -PspongeCertificateFingerprint=${spongeCertFingerprint} clean build changelog'''
                     bash '''#!/bin/bash -e
                         cat >.gradle/upload.gradle <<EOF
                         allprojects {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,9 +11,6 @@ pipeline {
         }
 
         stage('Build') {
-            environment {
-                MAVEN = credentials('maven')
-            }
             steps {
                 sh '''./gradlew --refresh-dependencies
                 -s

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,52 +27,52 @@ pipeline {
         stage('publish') {
             steps {
                 withCredentials([string(credentialsId: 'spongeMavenUsername', variable: 'spongeMavenUsername'), string(credentialsId: 'spongeMavenPassword', variable: 'spongeMavenPassword'), string(credentialsId: 'spongeIndexerUsername', variable: 'spongeIndexerUsername'), string(credentialsId: 'spongeIndexerPassword', variable: 'spongeIndexerPassword'), string(credentialsId: 'spongeKeyStore', variable: 'spongeKeyStore'), string(credentialsId: 'spongeKeyStoreAlias', variable: 'spongeKeyStoreAlias'), string(credentialsId: 'spongeKeyStorePass', variable: 'spongeKeyStorePass'), string(credentialsId: 'spongeKeyStorePass', variable: 'spongeKeyStoreKeyPass')]) {
-                    sh '''#!/bin/bash -e
-                    cat >.gradle/upload.gradle <<EOF
-                    allprojects {
-                        tasks.all {
-                            if (it.name != \'uploadArchives\') {
-                                enabled = false
-                            }
-                        }
-                    }
-                    EOF
+sh '''#!/bin/bash -e
+cat >.gradle/upload.gradle <<EOF
+allprojects {
+    tasks.all {
+        if (it.name != \'uploadArchives\') {
+            enabled = false
+        }
+    }
+}
+EOF
 
-                    deploy() {
-                        echo "Uploading artifacts to $1"
-                        if ./gradlew -I .gradle/upload.gradle \\
-                            -s -q \\
-                            -PspongeRepo=$1 \\
-                            -PspongeUsername=$2 \\
-                            -PspongePassword=$3 \\
-                            -PforgeJenkinsPass=${spongeJenkinsPassword} \\
-                            :uploadArchives
-                        then
-                            echo "Successfully uploaded artifacts to $1"
-                        else
-                            echo "Failed to upload artifacts to $1"
-                            exit 1
-                        fi
-                    }
+deploy() {
+    echo "Uploading artifacts to $1"
+    if ./gradlew -I .gradle/upload.gradle \\
+        -s -q \\
+        -PspongeRepo=$1 \\
+        -PspongeUsername=$2 \\
+        -PspongePassword=$3 \\
+        -PforgeJenkinsPass=${spongeJenkinsPassword} \\
+        :uploadArchives
+    then
+        echo "Successfully uploaded artifacts to $1"
+    else
+        echo "Failed to upload artifacts to $1"
+        exit 1
+    fi
+}
 
-                    promoteLatest() {
-                        echo "Promoting latest build"
-                        curl --user "$1:$2" http://files.minecraftforge.net/maven/manage/promote/latest/org.spongepowered.spongeforge/${BUILD_NUMBER}
-                    }
+promoteLatest() {
+    echo "Promoting latest build"
+    curl --user "$1:$2" http://files.minecraftforge.net/maven/manage/promote/latest/org.spongepowered.spongeforge/${BUILD_NUMBER}
+}
 
-                    deploy "http://files.minecraftforge.net/maven/manage/upload" "${spongeMavenUsername}" "${spongeMavenPassword}" \\
-                        && promoteLatest "${spongeMavenUsername}" "${spongeMavenPassword}" &
-                    pids="$!"
-                    deploy "https://dl-indexer.spongepowered.org/maven/upload" "${spongeIndexerUsername}" "${spongeIndexerPassword}" &
-                    pids="$pids $!"
+deploy "http://files.minecraftforge.net/maven/manage/upload" "${spongeMavenUsername}" "${spongeMavenPassword}" \\
+    && promoteLatest "${spongeMavenUsername}" "${spongeMavenPassword}" &
+pids="$!"
+deploy "https://dl-indexer.spongepowered.org/maven/upload" "${spongeIndexerUsername}" "${spongeIndexerPassword}" &
+pids="$pids $!"
 
-                    result=0
-                    for pid in $pids; do
-                        wait $pid || result=1
-                    done
-                    exit $result
+result=0
+for pid in $pids; do
+    wait $pid || result=1
+done
+exit $result
 
-                    '''
+'''
 
                 }
             }
@@ -80,7 +80,9 @@ pipeline {
     }
     post {
         always {
-            archiveArtifacts artifacts: 'SpongeForge/build/libs/**/*.jar', fingerprint: true
+            archiveArtifacts artifacts: '*/build/libs/**/*.jar', fingerprint: true
+            //junit 'build/test-results/*/*.xml'
+            //jacoco sourcePattern: '**/src/*/java'
         }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,6 +3,7 @@
 pipeline {
     agent any
 
+    withCredentials([string(credentialsId: 'spongeMavenUsername', variable: 'spongeMavenUsername'), string(credentialsId: 'spongeMavenPassword', variable: 'spongeMavenPassword'), string(credentialsId: 'spongeIndexerUsername', variable: 'spongeIndexerUsername'), string(credentialsId: 'spongeIndexerPassword', variable: 'spongeIndexerPassword'), string(credentialsId: 'spongeKeyStore', variable: 'spongeKeyStore'), string(credentialsId: 'spongeKeyStoreAlias', variable: 'spongeKeyStoreAlias'), string(credentialsId: 'spongeKeyStorePass', variable: 'spongeKeyStorePass'), string(credentialsId: 'spongeKeyStorePass', variable: 'spongeKeyStoreKeyPass')]) {
     stages {
         stage('Prepare') {
             steps {
@@ -11,7 +12,6 @@ pipeline {
         }
 
         stage('Build') {
-        withCredentials([string(credentialsId: 'spongeMavenUsername', variable: 'spongeMavenUsername'), string(credentialsId: 'spongeMavenPassword', variable: 'spongeMavenPassword'), string(credentialsId: 'spongeIndexerUsername', variable: 'spongeIndexerUsername'), string(credentialsId: 'spongeIndexerPassword', variable: 'spongeIndexerPassword'), string(credentialsId: 'spongeKeyStore', variable: 'spongeKeyStore'), string(credentialsId: 'spongeKeyStoreAlias', variable: 'spongeKeyStoreAlias'), string(credentialsId: 'spongeKeyStorePass', variable: 'spongeKeyStorePass'), string(credentialsId: 'spongeKeyStorePass', variable: 'spongeKeyStoreKeyPass')]) {
             steps {
                 sh '''./gradlew --refresh-dependencies -s
                 -PforgeJenkinsPass=${forgeJenkinsPass}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,7 +27,7 @@ pipeline {
         stage('publish') {
             steps {
                 withCredentials([string(credentialsId: 'spongeMavenUsername', variable: 'spongeMavenUsername'), string(credentialsId: 'spongeMavenPassword', variable: 'spongeMavenPassword'), string(credentialsId: 'spongeIndexerUsername', variable: 'spongeIndexerUsername'), string(credentialsId: 'spongeIndexerPassword', variable: 'spongeIndexerPassword'), string(credentialsId: 'spongeKeyStore', variable: 'spongeKeyStore'), string(credentialsId: 'spongeKeyStoreAlias', variable: 'spongeKeyStoreAlias'), string(credentialsId: 'spongeKeyStorePass', variable: 'spongeKeyStorePass'), string(credentialsId: 'spongeKeyStorePass', variable: 'spongeKeyStoreKeyPass')]) {
-                    bash '''#!/bin/bash -e
+                     sh '''#!/bin/bash -e
                         cat >.gradle/upload.gradle <<EOF
                         allprojects {
                             tasks.all {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,7 +14,7 @@ pipeline {
             steps {
                 withCredentials([string(credentialsId: 'spongeMavenUsername', variable: 'spongeMavenUsername'), string(credentialsId: 'spongeMavenPassword', variable: 'spongeMavenPassword'), string(credentialsId: 'spongeIndexerUsername', variable: 'spongeIndexerUsername'), string(credentialsId: 'spongeIndexerPassword', variable: 'spongeIndexerPassword'), string(credentialsId: 'spongeKeyStore', variable: 'spongeKeyStore'), string(credentialsId: 'spongeKeyStoreAlias', variable: 'spongeKeyStoreAlias'), string(credentialsId: 'spongeKeyStorePass', variable: 'spongeKeyStorePass'), string(credentialsId: 'spongeKeyStorePass', variable: 'spongeKeyStoreKeyPass')]) {
 
-                    sh '''./gradlew --refresh-dependencies -s -PforgeJenkinsPass=${forgeJenkinsPass} -PspongeKeyStore=${spongeKeyStore}  -PspongeKeyStoreAlias=${spongeKeyStoreAlias} -PspongeKeyStorePass=${spongeKeyStorePass} -PspongeKeyStoreKeyPass=${spongeKeyStoreKeyPass} -PspongeCertificateFingerprint=${spongeCertFingerprint} clean build changelog'''
+                    sh '''./gradlew --refresh-dependencies -s -PforgeJenkinsPass=${forgeJenkinsPass} -PspongeKeyStore=${spongeKeyStore}  -PspongeKeyStoreAlias=${spongeKeyStoreAlias} -PspongeKeyStorePass=${spongeKeyStorePass} -PspongeKeyStoreKeyPass=${spongeKeyStoreKeyPass} -PspongeCertificateFingerprint=${spongeCertFingerprint} clean build'''
                     bash '''#!/bin/bash -e
                         cat >.gradle/upload.gradle <<EOF
                         allprojects {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,9 +11,9 @@ pipeline {
         }
 
         stage('Build') {
+        withCredentials([string(credentialsId: 'spongeMavenUsername', variable: 'spongeMavenUsername'), string(credentialsId: 'spongeMavenPassword', variable: 'spongeMavenPassword'), string(credentialsId: 'spongeIndexerUsername', variable: 'spongeIndexerUsername'), string(credentialsId: 'spongeIndexerPassword', variable: 'spongeIndexerPassword'), string(credentialsId: 'spongeKeyStore', variable: 'spongeKeyStore'), string(credentialsId: 'spongeKeyStoreAlias', variable: 'spongeKeyStoreAlias'), string(credentialsId: 'spongeKeyStorePass', variable: 'spongeKeyStorePass'), string(credentialsId: 'spongeKeyStorePass', variable: 'spongeKeyStoreKeyPass')]) {
             steps {
-                sh '''./gradlew --refresh-dependencies
-                -s
+                sh '''./gradlew --refresh-dependencies -s
                 -PforgeJenkinsPass=${forgeJenkinsPass}
                               -PspongeKeyStore=${spongeKeyStore}
                               -PspongeKeyStoreAlias=${spongeKeyStoreAlias}
@@ -35,8 +35,8 @@ pipeline {
 
                     deploy() {
                         echo "Uploading artifacts to $1"
-                        if ./gradlew -I .gradle/upload.gradle \
-                            -s -q \
+                        if ./gradlew -I .gradle/upload.gradle \\
+                            -q \
                             -PspongeRepo=$1 \
                             -PspongeUsername=$2 \
                             -PspongePassword=$3 \
@@ -72,6 +72,7 @@ pipeline {
 
 
             }
+        }
         }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,80 @@
+@Library('forge-shared-library')_
+
+pipeline {
+    agent any
+
+    stages {
+        stage('Prepare') {
+            steps {
+                sh './gradlew --refresh-dependencies -s clean setupDecompWorkspace'
+            }
+        }
+
+        stage('Build') {
+            environment {
+                MAVEN = credentials('maven')
+            }
+            steps {
+                sh '''./gradlew --refresh-dependencies
+                -s
+                -PforgeJenkinsPass=${forgeJenkinsPass}
+                              -PspongeKeyStore=${spongeKeyStore}
+                              -PspongeKeyStoreAlias=${spongeKeyStoreAlias}
+                              -PspongeKeyStorePass=${spongeKeyStorePass}
+                              -PspongeKeyStoreKeyPass=${spongeKeyStoreKeyPass}
+                              -PspongeCertificateFingerprint=${spongeCertFingerprint}
+                              clean build changelog'
+                              '''
+                bash '''#!/bin/bash -e
+                    cat >.gradle/upload.gradle <<EOF
+                    allprojects {
+                        tasks.all {
+                            if (it.name != 'uploadArchives') {
+                                enabled = false
+                            }
+                        }
+                    }
+                    EOF
+
+                    deploy() {
+                        echo "Uploading artifacts to $1"
+                        if ./gradlew -I .gradle/upload.gradle \
+                            -s -q \
+                            -PspongeRepo=$1 \
+                            -PspongeUsername=$2 \
+                            -PspongePassword=$3 \
+                            -PforgeJenkinsPass=${spongeJenkinsPassword} \
+                            :uploadArchives
+                        then
+                            echo "Successfully uploaded artifacts to $1"
+                        else
+                            echo "Failed to upload artifacts to $1"
+                            exit 1
+                        fi
+                    }
+
+                    promoteLatest() {
+                        echo "Promoting latest build"
+                        curl --user "$1:$2" http://files.minecraftforge.net/maven/manage/promote/latest/org.spongepowered.spongeforge/${BUILD_NUMBER}
+                    }
+
+                    deploy "http://files.minecraftforge.net/maven/manage/upload" "${spongeMavenUsername}" "${spongeMavenPassword}" \
+                        && promoteLatest "${spongeMavenUsername}" "${spongeMavenPassword}" &
+                    pids="$!"
+                    deploy "https://dl-indexer.spongepowered.org/maven/upload" "${spongeIndexerUsername}" "${spongeIndexerPassword}" &
+                    pids="$pids $!"
+
+                    result=0
+                    for pid in $pids; do
+                        wait $pid || result=1
+                    done
+                    exit $result
+
+                    '''
+
+
+
+            }
+        }
+    }
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,54 +27,60 @@ pipeline {
         stage('publish') {
             steps {
                 withCredentials([string(credentialsId: 'spongeMavenUsername', variable: 'spongeMavenUsername'), string(credentialsId: 'spongeMavenPassword', variable: 'spongeMavenPassword'), string(credentialsId: 'spongeIndexerUsername', variable: 'spongeIndexerUsername'), string(credentialsId: 'spongeIndexerPassword', variable: 'spongeIndexerPassword'), string(credentialsId: 'spongeKeyStore', variable: 'spongeKeyStore'), string(credentialsId: 'spongeKeyStoreAlias', variable: 'spongeKeyStoreAlias'), string(credentialsId: 'spongeKeyStorePass', variable: 'spongeKeyStorePass'), string(credentialsId: 'spongeKeyStorePass', variable: 'spongeKeyStoreKeyPass')]) {
-                     sh '''#!/bin/bash -e
-                        cat >.gradle/upload.gradle <<EOF
-                        allprojects {
-                            tasks.all {
-                                if (it.name != 'uploadArchives') {
-                                    enabled = false
-                                }
+                    sh '''#!/bin/bash -e
+                    cat >.gradle/upload.gradle <<EOF
+                    allprojects {
+                        tasks.all {
+                            if (it.name != \'uploadArchives\') {
+                                enabled = false
                             }
                         }
-                        EOF
+                    }
+                    EOF
 
-                        deploy() {
-                            echo "Uploading artifacts to $1"
-                            if ./gradlew -I .gradle/upload.gradle \\
-                                -q \
-                                -PspongeRepo=$1 \
-                                -PspongeUsername=$2 \
-                                -PspongePassword=$3 \
-                                -PforgeJenkinsPass=${spongeJenkinsPassword} \
-                                :uploadArchives
-                            then
-                                echo "Successfully uploaded artifacts to $1"
-                            else
-                                echo "Failed to upload artifacts to $1"
-                                exit 1
-                            fi
-                        }
+                    deploy() {
+                        echo "Uploading artifacts to $1"
+                        if ./gradlew -I .gradle/upload.gradle \\
+                            -s -q \\
+                            -PspongeRepo=$1 \\
+                            -PspongeUsername=$2 \\
+                            -PspongePassword=$3 \\
+                            -PforgeJenkinsPass=${spongeJenkinsPassword} \\
+                            :uploadArchives
+                        then
+                            echo "Successfully uploaded artifacts to $1"
+                        else
+                            echo "Failed to upload artifacts to $1"
+                            exit 1
+                        fi
+                    }
 
-                        promoteLatest() {
-                           echo "Promoting latest build"
-                           curl --user "$1:$2" http://files.minecraftforge.net/maven/manage/promote/latest/org.spongepowered.spongeforge/${BUILD_NUMBER}
-                         }
+                    promoteLatest() {
+                        echo "Promoting latest build"
+                        curl --user "$1:$2" http://files.minecraftforge.net/maven/manage/promote/latest/org.spongepowered.spongeforge/${BUILD_NUMBER}
+                    }
 
-                        deploy "http://files.minecraftforge.net/maven/manage/upload" "${spongeMavenUsername}" "${spongeMavenPassword}" \
-                           && promoteLatest "${spongeMavenUsername}" "${spongeMavenPassword}" &
-                         pids="$!"
-                         deploy "https://dl-indexer.spongepowered.org/maven/upload" "${spongeIndexerUsername}" "${spongeIndexerPassword}" &
-                         pids="$pids $!"
+                    deploy "http://files.minecraftforge.net/maven/manage/upload" "${spongeMavenUsername}" "${spongeMavenPassword}" \\
+                        && promoteLatest "${spongeMavenUsername}" "${spongeMavenPassword}" &
+                    pids="$!"
+                    deploy "https://dl-indexer.spongepowered.org/maven/upload" "${spongeIndexerUsername}" "${spongeIndexerPassword}" &
+                    pids="$pids $!"
 
-                        result=0
-                        for pid in $pids; do
-                           wait $pid || result=1
-                         done
-                         exit $result
+                    result=0
+                    for pid in $pids; do
+                        wait $pid || result=1
+                    done
+                    exit $result
 
-                        '''
+                    '''
+
                 }
             }
+        }
+    }
+    post {
+        always {
+            archiveArtifacts artifacts: 'SpongeForge/build/libs/**/*.jar', fingerprint: true
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,6 @@ ext.implementationId = "spongeforge"
 apply from: project(':SpongeCommon').file('gradle/implementation.gradle')
 
 version = "$minecraft.version-$forgeBuild-$implementationVersion"
-System.err.println(version)
 minecraft {
     coreMod = 'org.spongepowered.mod.SpongeCoremod'
     replace '@expected_certificate_fingerprint@', project.hasProperty('spongeCertificateFingerprint') ? project.property('spongeCertificateFingerprint') : ''

--- a/build.gradle
+++ b/build.gradle
@@ -27,12 +27,13 @@ buildscript {
 // On Forge, we use the Forge build number as Minecraft version for ForgeGradle
 ext.minecraftVersion = forgeBuild
 ext.testmods = project.project('testmods')
+ext.implementationId = "spongeforge"
 
 // Apply shared implementation Gradle config
 apply from: project(':SpongeCommon').file('gradle/implementation.gradle')
 
-version = "$minecraft.version-$forgeBuild-$apiSuffix-$buildNumber"
-
+version = "$minecraft.version-$forgeBuild-$implementationVersion"
+System.err.println(version)
 minecraft {
     coreMod = 'org.spongepowered.mod.SpongeCoremod'
     replace '@expected_certificate_fingerprint@', project.hasProperty('spongeCertificateFingerprint') ? project.property('spongeCertificateFingerprint') : ''

--- a/src/main/java/org/spongepowered/mod/SpongeCommonModContainer.java
+++ b/src/main/java/org/spongepowered/mod/SpongeCommonModContainer.java
@@ -40,4 +40,9 @@ public class SpongeCommonModContainer extends MetaModContainer {
         return SpongeCoremod.modFile;
     }
 
+    @Override
+    public Object getMod() {
+        // We need to return an instance of the mod with the mod container.
+        return this;
+    }
 }

--- a/src/main/java/org/spongepowered/mod/SpongeCommonModContainer.java
+++ b/src/main/java/org/spongepowered/mod/SpongeCommonModContainer.java
@@ -1,0 +1,43 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.mod;
+
+import org.spongepowered.common.SpongeImpl;
+import org.spongepowered.mod.plugin.MetaModContainer;
+
+import java.io.File;
+
+public class SpongeCommonModContainer extends MetaModContainer {
+
+    public SpongeCommonModContainer() {
+        super(SpongeModMetadata.get(SpongeImpl.ECOSYSTEM_ID, SpongeImpl.ECOSYSTEM_NAME));
+    }
+
+    @Override
+    public File getSource() {
+        return SpongeCoremod.modFile;
+    }
+
+}

--- a/src/main/java/org/spongepowered/mod/SpongeCoremod.java
+++ b/src/main/java/org/spongepowered/mod/SpongeCoremod.java
@@ -171,6 +171,7 @@ public class SpongeCoremod implements IFMLLoadingPlugin {
     public void injectData(Map<String, Object> data) {
         // Register SpongeAPI mod container
         FMLInjectionData.containers.add("org.spongepowered.mod.SpongeApiModContainer");
+        FMLInjectionData.containers.add("org.spongepowered.mod.SpongeCommonModContainer");
 
         modFile = (File) data.get("coremodLocation");
         if (modFile == null) {

--- a/src/main/java/org/spongepowered/mod/SpongeMod.java
+++ b/src/main/java/org/spongepowered/mod/SpongeMod.java
@@ -165,6 +165,7 @@ public class SpongeMod extends MetaModContainer {
         // Do not replace `SpongeImpl.getLogger()` with `this.getLogger()`. You've been warned.
         SpongeImpl.getLogger().info("Creating injector in stage '{}'", stage);
         Guice.createInjector(stage, new SpongeModule(), new SpongeForgeModule());
+        Sponge.getPluginManager().getPlugin(SpongeImpl.ECOSYSTEM_ID).ifPresent(SpongeImpl::setSpongePlugin);
 
         SpongeImpl.getRegistry().preRegistryInit();
         SpongeGameData.addRegistryCallback(ForgeRegistries.BLOCKS, (owner, manager, id, obj, oldObj) -> {

--- a/src/main/java/org/spongepowered/mod/SpongeModMetadata.java
+++ b/src/main/java/org/spongepowered/mod/SpongeModMetadata.java
@@ -28,6 +28,7 @@ import com.google.common.collect.ImmutableMap;
 import net.minecraftforge.fml.common.MetadataCollection;
 import net.minecraftforge.fml.common.ModMetadata;
 import org.spongepowered.common.SpongeImpl;
+import org.spongepowered.common.SpongeImplHooks;
 import org.spongepowered.plugin.meta.McModInfo;
 
 import java.io.IOException;
@@ -114,7 +115,7 @@ public final class SpongeModMetadata {
     }
 
     public static ModMetadata getSpongeForgeMetadata() {
-        return get(SpongeImpl.ECOSYSTEM_ID, "SpongeForge");
+        return get(SpongeImplHooks.getImplementationId(), "SpongeForge");
     }
 
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/common/MixinSpongeImplHooks.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/common/MixinSpongeImplHooks.java
@@ -761,4 +761,8 @@ public abstract class MixinSpongeImplHooks {
         net.minecraftforge.server.timings.TimeTracker.ENTITY_UPDATE.trackEnd(entity);
     }
 
+    @Overwrite
+    public static String getImplementationId() {
+        return "spongeforge";
+    }
 }

--- a/src/main/resources/mcmod.info
+++ b/src/main/resources/mcmod.info
@@ -1,6 +1,6 @@
 [
     {
-        "modid": "sponge",
+        "modid": "spongeforge",
         "updateJSON": "https://files.minecraftforge.net/maven/org/spongepowered/spongeforge/promotions_slim.json",
         "credits": "Copyright (C) SpongePowered and contributors",
         "logoFile": "/org/spongepowered/launch/gui/sponge_logo.png"


### PR DESCRIPTION
[SpongeCommon](https://github.com/SpongePowered/SpongeCommon/pull/2116) | [SpongeVanilla](https://github.com/SpongePowered/SpongeVanilla/pull/391) | **SpongeForge**
To sumarize https://github.com/SpongePowered/SpongeForge/issues/2367:

We are changing our versioning string format for SpongeForge, SpongeVanilla, SpongeCommon, and SpongeAPI.

Because SpongeAPI 7.1.0 has already been released, we will not be making the change to drop the `patchVersion` of the API until API 8.

As of right now however, SpongeCommon has a full blown PluginContainer provided by both implementations (implemented slightly differently due to one having complete control over plugin containers and the other, well, not so much).

Looking for feedback from @Minecrell and others to maybe improve these changes so they're not so ~~janky~~ cluttered.

NOTE:

I currently still have initialization issues where SpongeCommon's implementation does not have an associated plugin instance. I can't figure out how to implement such a plugin instance for Forge's mod containers, but I might just bypass the issue entirely by using SpongeForge's mod container.