### PR TITLE
Fix listener count not getting incremented on Forge event register

### DIFF
--- a/src/main/java/org/spongepowered/mod/mixin/core/fml/common/eventhandler/MixinEventBus.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/fml/common/eventhandler/MixinEventBus.java
@@ -211,13 +211,11 @@ public abstract class MixinEventBus implements IMixinEventBus {
 
         SpongeModEventManager manager = ((SpongeModEventManager) SpongeImpl.getGame().getEventManager());
 
-        if (!forgeListenerEventClasses.contains(eventType)) {
-            for (Class clazz : TypeToken.of(eventType).getTypes().rawTypes()) {
-                Collection<Class<? extends org.spongepowered.api.event.Event>> spongeEvents = manager.forgeToSpongeEventMapping.get(clazz);
-                if (spongeEvents != null) {
-                    for (Class<? extends org.spongepowered.api.event.Event> event : spongeEvents) {
-                        manager.checker.registerListenerFor(event);
-                    }
+        for (Class clazz : TypeToken.of(eventType).getTypes().rawTypes()) {
+            Collection<Class<? extends org.spongepowered.api.event.Event>> spongeEvents = manager.forgeToSpongeEventMapping.get(clazz);
+            if (spongeEvents != null) {
+                for (Class<? extends org.spongepowered.api.event.Event> event : spongeEvents) {
+                    manager.checker.registerListenerFor(event);
                 }
             }
         }


### PR DESCRIPTION
This undoes a change made by this commit: https://github.com/SpongePowered/SpongeForge/commit/6262a92b6fb9df7c2ba9a3bc57b5f9bad49f6698#diff-e136d0f5f960839144bd45ccc3e2d104R187

The check `!forgeListenerEventClasses.contains(eventType)` prevents Sponge from incrementing the listener count for that eventType and as a result when events get unregistered the counter for that eventType will fall below 0 which shouldn't happen.

Fixes #2412 