### PR TITLE
Fix NPE with SidedDelegate

### DIFF
--- a/src/main/java/org/spongepowered/mod/SpongeMod.java
+++ b/src/main/java/org/spongepowered/mod/SpongeMod.java
@@ -154,6 +154,9 @@ public class SpongeMod extends MetaModContainer {
             if (SERVER_THREAD != null) {
                 return SERVER_THREAD == current;
             }
+            if (FMLCommonHandler.instance().getSidedDelegate() == null) {
+                return false;
+            }
             final NetworkManager client = FMLCommonHandler.instance().getClientToServerNetworkManager();
             // Here we're just checking if we're connected to a server and
             // connected to that server, because the connection would no longer


### PR DESCRIPTION
Fixes `NullPointerException` caused by calling `getClientToServerNetworkManager`. This is preventing the Server side from starting