### PR TITLE
Fire server-side TickEvents on Sponge's event bus.

### DIFF
--- a/src/main/java/org/spongepowered/mod/mixin/core/fml/common/eventhandler/EventBusMixin_Forge.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/fml/common/eventhandler/EventBusMixin_Forge.java
@@ -44,6 +44,7 @@ import net.minecraftforge.fml.common.eventhandler.IEventExceptionHandler;
 import net.minecraftforge.fml.common.eventhandler.IEventListener;
 import net.minecraftforge.fml.common.eventhandler.ListenerList;
 import net.minecraftforge.fml.common.gameevent.TickEvent;
+import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.oredict.OreDictionary;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
@@ -164,7 +165,7 @@ public abstract class EventBusMixin_Forge implements EventBusBridge_Forge {
     }
 
     private boolean forgeImpl$isIgnoredEvent(final Event event) {
-        if (event instanceof TickEvent) {
+        if (event instanceof TickEvent && ((TickEvent) event).side == Side.CLIENT) {
             return true;
         }
         if (event instanceof EntityEvent.CanUpdate) {


### PR DESCRIPTION
This change lets Sponge push phase states for tick events, allowing us to capture changes from mods during those events. I intentionally left client-side ticks on Forge's event bus, but I'm requesting a review in case there's some other case I'm missing.

Fixes #2789.