### PR TITLE
Log chunk load queue

### DIFF
--- a/src/main/java/org/spongepowered/mod/mixin/core/forge/common/chunkio/ChunkIOExecutorMixin_Forge.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/forge/common/chunkio/ChunkIOExecutorMixin_Forge.java
@@ -1,0 +1,46 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.mod.mixin.core.forge.common.chunkio;
+
+import com.flowpowered.math.vector.Vector3i;
+import net.minecraft.world.World;
+import net.minecraft.world.chunk.storage.AnvilChunkLoader;
+import net.minecraft.world.gen.ChunkProviderServer;
+import net.minecraftforge.common.chunkio.ChunkIOExecutor;
+import org.spongepowered.api.world.Chunk;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.common.util.SpongeHooks;
+
+@Mixin(ChunkIOExecutor.class)
+public class ChunkIOExecutorMixin_Forge {
+
+    @Inject(method = "queueChunkLoad", at = @At(value = "INVOKE", target = "Ljava/util/concurrent/ThreadPoolExecutor;execute(Ljava/lang/Runnable;)V"))
+    private static void forgeImpl$onQueue(World world, AnvilChunkLoader loader, ChunkProviderServer provider, int x, int z, Runnable runnable, final CallbackInfo ci) {
+        SpongeHooks.logChunkQueueLoad(world, Vector3i.from(x, 0, z));
+    }
+}

--- a/src/main/java/org/spongepowered/mod/mixin/core/forge/common/chunkio/ChunkIOExecutorMixin_Forge.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/forge/common/chunkio/ChunkIOExecutorMixin_Forge.java
@@ -40,7 +40,7 @@ import org.spongepowered.common.util.SpongeHooks;
 public class ChunkIOExecutorMixin_Forge {
 
     @Inject(method = "queueChunkLoad", at = @At(value = "INVOKE", target = "Ljava/util/concurrent/ThreadPoolExecutor;execute(Ljava/lang/Runnable;)V"))
-    private static void forgeImpl$onQueue(World world, AnvilChunkLoader loader, ChunkProviderServer provider, int x, int z, Runnable runnable, final CallbackInfo ci) {
+    private static void forgeImpl$logQueueLoading(World world, AnvilChunkLoader loader, ChunkProviderServer provider, int x, int z, Runnable runnable, final CallbackInfo ci) {
         SpongeHooks.logChunkQueueLoad(world, Vector3i.from(x, 0, z));
     }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/forge/common/chunkio/ChunkIOExecutorMixin_Forge.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/forge/common/chunkio/ChunkIOExecutorMixin_Forge.java
@@ -36,7 +36,7 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.common.util.SpongeHooks;
 
-@Mixin(ChunkIOExecutor.class)
+@Mixin(value = ChunkIOExecutor.class, remap = false)
 public class ChunkIOExecutorMixin_Forge {
 
     @Inject(method = "queueChunkLoad", at = @At(value = "INVOKE", target = "Ljava/util/concurrent/ThreadPoolExecutor;execute(Ljava/lang/Runnable;)V"))

--- a/src/main/resources/mixins.forge.core.json
+++ b/src/main/resources/mixins.forge.core.json
@@ -42,6 +42,7 @@
         "forge.common.ForgeChunkManager$TicketAccessor",
         "forge.common.ForgeHooksMixin_Forge",
         "forge.common.ForgeInternalHandlerMixin_Forge",
+        "forge.common.chunkio.ChunkIOExecutorMixin_Forge",
         "forge.common.chunkio.ChunkIOProviderMixin_Forge",
         "forge.common.util.BlockSnapshotMixin_Forge",
         "forge.common.util.ITeleporterMixin_Forge",


### PR DESCRIPTION
**SpongeForge** | [SpongeCommon](https://github.com/SpongePowered/SpongeCommon/pull/2626) 

Chunks can be queued to load. When chunk-load logging is enabled this is the result

```
[20:02:27] [Server thread/INFO] [Sponge]: Load Chunk At [0] (1,251, 1,250)
[20:02:27] [Server thread/INFO] [Sponge]: Catching
java.lang.Throwable: null
	at org.spongepowered.common.util.SpongeHooks.logStack(SpongeHooks.java:107) [SpongeHooks.class:?]
	at org.spongepowered.common.util.SpongeHooks.logChunkLoad(SpongeHooks.java:206) [SpongeHooks.class:?]
	at net.minecraft.world.chunk.Chunk.handler$zmb000$impl$UpdateNeighborsOnLoad(Chunk.java:3648) [Chunk.class:?]
	at net.minecraft.world.chunk.Chunk.onLoad(Chunk.java:923) [Chunk.class:?]
	at net.minecraftforge.common.chunkio.ChunkIOProvider.syncCallback(ChunkIOProvider.java:109) [ChunkIOProvider.class:?]
	at net.minecraftforge.common.chunkio.ChunkIOExecutor.tick(ChunkIOExecutor.java:150) [ChunkIOExecutor.class:?]
	at net.minecraft.server.MinecraftServer.updateTimeLightAndEntities(MinecraftServer.java:803) [MinecraftServer.class:?]
	at net.minecraft.server.dedicated.DedicatedServer.updateTimeLightAndEntities(DedicatedServer.java:415) [DedicatedServer.class:?]
	at net.minecraft.server.MinecraftServer.tick(MinecraftServer.java:743) [MinecraftServer.class:?]
	at net.minecraft.server.MinecraftServer.run(MinecraftServer.java:592) [MinecraftServer.class:?]
	at java.lang.Thread.run(Thread.java:748) [?:1.8.0_212]
```

The stacktrace is not helpful since it doesn't show how said chunk was scheduled to load.
This PR add a log message when a chunk is queued.