### PR TITLE
Clean registry tmp maps once the server started

### DIFF
--- a/src/main/java/org/spongepowered/mod/SpongeMod.java
+++ b/src/main/java/org/spongepowered/mod/SpongeMod.java
@@ -564,6 +564,7 @@ public class SpongeMod extends MetaModContainer {
 
     @Subscribe
     public void onServerStarted(FMLServerStartedEvent event) {
+        SpongeImpl.getRegistry().clear();
         // Flush what needs to be saved.
         SpongeImpl.getConfigSaveManager().flush();
 


### PR DESCRIPTION
Forgot to open this back when I refactored registry module registration in common

The method in SC is here (it was added but never used)

https://github.com/SpongePowered/SpongeCommon/blob/8980791be11f94d86d4514cf6c023bdfb61f5f75/src/main/java/org/spongepowered/common/registry/SpongeGameRegistry.java#L576

`MODULES` is already set to null in `registerInitModulePhase`
`ORDERED_MODULES` and `REGISTRIES` will be empty if the server started correctly

`REGISTRY_CLASS_MAP` and `REGISTRY_CATALOG_MAP` are the only noticeable maps (with a size of around 150)

