### PR TITLE
Move entity death logging to common and remove internal listener for LivingDeathEvent

### DIFF
--- a/src/main/java/org/spongepowered/mod/SpongeMod.java
+++ b/src/main/java/org/spongepowered/mod/SpongeMod.java
@@ -480,12 +480,6 @@ public class SpongeMod extends MetaModContainer {
         }
     }
 
-
-    @SubscribeEvent
-    public void onEntityDeathEvent(LivingDeathEvent event) {
-        SpongeHooks.logEntityDeath(event.getEntity());
-    }
-
     @SubscribeEvent
     public void onForceChunk(ForgeChunkManager.ForceChunkEvent event) {
         final net.minecraft.world.chunk.Chunk chunk = ((ChunkProviderBridge) event.getTicket().world.getChunkProvider())


### PR DESCRIPTION
[SpongeCommon](https://github.com/SpongePowered/SpongeCommon/pull/2651) | **SpongeForge**