### PR TITLE
Add Forge reachDistance attribute modifier support to entities (SpongeCommon#2513)

### DIFF
--- a/src/main/java/org/spongepowered/mod/mixin/core/common/SpongeImplHooksMixin_Forge.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/common/SpongeImplHooksMixin_Forge.java
@@ -271,6 +271,16 @@ public abstract class SpongeImplHooksMixin_Forge {
         return player.interactionManager.getBlockReachDistance();
     }
 
+    /**
+     * @author Polyacov_Yury
+     * @reason Forge reachDistance attribute compatibility
+     */
+    @Overwrite
+    public static double getEntityReachDistanceSq(final EntityPlayerMP player) {
+        double reach = getBlockReachDistance(player);
+        return reach * reach;
+    }
+
     // Entity registry
 
     /**

--- a/src/main/java/org/spongepowered/mod/mixin/core/common/SpongeImplHooksMixin_Forge.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/common/SpongeImplHooksMixin_Forge.java
@@ -276,7 +276,7 @@ public abstract class SpongeImplHooksMixin_Forge {
      * @reason Forge reachDistance attribute compatibility
      */
     @Overwrite
-    public static double getEntityReachDistanceSq(final EntityPlayerMP player) {
+    public static double getEntityReachDistanceSq(final EntityPlayerMP player, Entity entity) {
         double reach = getBlockReachDistance(player);
         return reach * reach;
     }


### PR DESCRIPTION
Also what title says.

Without this, attacking entities with a sword with reachDistance modifier only happens client-side.

Depends on SpongeCommon#3166, probably needs re-doing (commit includes a SpongeCommon bump).