### PR TITLE
Gradle Incremental compilation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -173,7 +173,7 @@ uploadArchives {
 }
 
 tasks.withType(JavaCompile) {
-   options.incremental = false
+   options.incremental = true
 }
 
 // Unfortunately, Mixin's annotation processor requires that SpongeCommon


### PR DESCRIPTION
[Incremental compilation](https://docs.gradle.org/current/userguide/performance.html#incremental_compilation). Gradle recompile only the classes that were affected by a change. This feature is the default since Gradle 4.10. For an older versions, we can activate it by setting `options.incremental = true`.
